### PR TITLE
Refactoring XMIR parser

### DIFF
--- a/parser/src/main/resources/simplify-xmir.xsl
+++ b/parser/src/main/resources/simplify-xmir.xsl
@@ -39,7 +39,7 @@
             </with>
         </copy>
     </xsl:template>
-    <xsl:template match="o[not(@base)]">
+    <xsl:template match="o[not(@base)]" priority="1">
         <abstraction>
             <xsl:if test="@name">
                 <xsl:attribute name="bound-to">
@@ -50,12 +50,12 @@
             <xsl:apply-templates select="*"/>
         </abstraction>
     </xsl:template>
-    <xsl:template match="o[not(@base) and @name and @line = parent::o/@line]">
+    <xsl:template match="o[not(@base) and @name and @line = parent::o/@line]" priority="2">
         <free name="{@name}">
             <xsl:apply-templates select="@vararg"/>
         </free>
     </xsl:template>
-    <xsl:template match="o[@data]">
+    <xsl:template match="o[@data]" priority="3">
         <data type="{@data}" value="{text()}">
             <xsl:if test="@name">
                 <xsl:attribute name="bound-to">

--- a/parser/src/main/scala/org/polystat/odin/parser/xmir/XmirToAst.scala
+++ b/parser/src/main/scala/org/polystat/odin/parser/xmir/XmirToAst.scala
@@ -3,6 +3,7 @@ package org.polystat.odin.parser.xmir
 import cats.effect.Sync
 import cats.implicits._
 import cats.Traverse
+import cats.data.Validated
 import com.github.tarao.nonempty.collection.NonEmpty
 import higherkindness.droste.data.Fix
 import org.polystat.odin.core.ast._
@@ -136,7 +137,11 @@ object XmirToAst {
       private[this] def combineErrors[A](
         eithers: Seq[Either[String, A]]
       ): Either[String, Seq[A]] = {
-        Traverse[Seq].sequence(eithers)
+        Traverse[Seq]
+          .traverse(eithers)(either =>
+            Validated.fromEither(either.leftMap(_ + "\n"))
+          )
+          .toEither
       }
 
       private[this] val bndFromTuple: ((Option[EONamedBnd], EOExprOnly)) => EOBnd[EOExprOnly] = {


### PR DESCRIPTION
 - Removed a lot of unnecessary Java XML boilerplate
 - Implemented `combineErrors` using `cats.Traverse`
 - `simplify-xmir.xsl` doesn't produce "ambiguous match" warnings