### PR TITLE
Release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# v0.2.0
+
+- Improved the algorithm of mutual recursion analyzer (see [#11]( https://github.com/polystat/odin/pull/11 ));
+- Rewrote EO parser with `cats-parse` (see [#10]( https://github.com/polystat/odin/pull/10 ));
+- Refactoring XMIR parser (see [#9]( https://github.com/polystat/odin/pull/9 ));
+- Make printing EO AST easier (see [2bf552e]( https://github.com/polystat/odin/commit/2bf552e ));

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.1.5-SNAPSHOT"
+ThisBuild / version := "0.2.0"


### PR DESCRIPTION
- Improved the algorithm of mutual recursion analyzer (see [#11]( https://github.com/polystat/odin/pull/11 ));
- Rewrote EO parser with `cats-parse` (see [#10]( https://github.com/polystat/odin/pull/10 ));
- Refactoring XMIR parser (see [#9]( https://github.com/polystat/odin/pull/9 ));
- Make printing EO AST easier (see [2bf552e]( https://github.com/polystat/odin/commit/2bf552e ));