### PR TITLE
Follow-up fixes for third defect type

### DIFF
--- a/analysis/src/main/scala/org/polystat/odin/analysis/EOOdinAnalyzer.scala
+++ b/analysis/src/main/scala/org/polystat/odin/analysis/EOOdinAnalyzer.scala
@@ -107,7 +107,7 @@ object EOOdinAnalyzer {
     mutualRecursionErrors <-
       analyzer
         .analyze(programAst)
-        .handleErrorWith(_ => Stream.empty)
+//        .handleErrorWith(_ => Stream.empty)
   } yield mutualRecursionErrors
 
 }

--- a/sandbox/src/main/scala/org/polystat/odin/sandbox/Sandbox.scala
+++ b/sandbox/src/main/scala/org/polystat/odin/sandbox/Sandbox.scala
@@ -7,24 +7,25 @@ object Sandbox extends IOApp {
 
   override def run(args: List[String]): IO[ExitCode] = for {
     exitCode <- IO.pure(ExitCode.Success)
-    code = """
-             |1 > seq
-             |2 > assert
-             |[] > a
-             |  [self x] > f
-             |    x.sub 5 > y1
-             |    seq > @
-             |      assert (0.less y1)
-             |  [self y] > g
-             |    self.f self y >  @
-             |  [self z] > h
-             |    z > @
-             |[] > b
-             |  a > @
-             |  [self y] > f
-             |    y > @
-             |  [self z] > h
-             |    self.g self z > @
+    code = """[] > test
+             |  [] > base
+             |    [self x] > f
+             |      x.sub 5 > y1
+             |      seq > @
+             |        assert (0.less y1)
+             |        x
+             |    [self y] > g
+             |      self.f self y >  @
+             |    [self z] > h
+             |      z > @
+             |
+             |  [] > derived
+             |    test.base > @
+             |    [self y] > f
+             |      y > @
+             |    [self z] > h
+             |      self.g self z > @
+             |
              |""".stripMargin
     analyzed <- IO(new EOOdinAnalyzer.EOOdinSourceCodeAnalyzer().analyze(code))
     _ <- IO.println(analyzed)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.2.2-SNAPSHOT"
+ThisBuild / version := "0.3.1-SNAPSHOT"


### PR DESCRIPTION
The following example works correctly both in Odin and Polystat:
```
[] > test
  [] > parent
    [self x] > f
      x.sub 5 > y1
      seq > @
        assert (0.less y1)
        x
    [self y] > g
      self.f self y > @
    [self z] > h
      z > @
  [] > child
    test.parent > @
    [self y] > f
      y > @
    [self z] > h
      self.g self z > @
```