### PR TITLE
Support "this" (and more) as the name of the "self" argument

### DIFF
--- a/analysis/src/main/scala/org/polystat/odin/analysis/liskov/Analyzer.scala
+++ b/analysis/src/main/scala/org/polystat/odin/analysis/liskov/Analyzer.scala
@@ -32,7 +32,11 @@ object Analyzer {
   )
 
   def convertMethodInfo(info: MethodInfo): MethodInfoForAnalysis =
-    MethodInfoForAnalysis(body = info.body, depth = info.depth)
+    MethodInfoForAnalysis(
+      selfArgName = info.selfArgName,
+      body = info.body,
+      depth = info.depth
+    )
 
   def processAnalysisInfo(
     method: MethodAnalysisInfo

--- a/analysis/src/main/scala/org/polystat/odin/analysis/unjustifiedassumptions/Analyzer.scala
+++ b/analysis/src/main/scala/org/polystat/odin/analysis/unjustifiedassumptions/Analyzer.scala
@@ -99,7 +99,12 @@ object Analyzer {
         // argument is self (need to check)
         val infos = body.bndAttrs.traverse {
           case EOBndExpr(bndName, expr) => {
-            extractInfo(bndName.name.name :: depth, expr, availableMethods)
+            extractInfo(
+              method.selfArgName,
+              bndName.name.name :: depth,
+              expr,
+              availableMethods
+            )
               .map(info => (bndName, info))
           }
         }

--- a/analysis/src/main/scala/org/polystat/odin/analysis/utils/inlining/Inliner.scala
+++ b/analysis/src/main/scala/org/polystat/odin/analysis/utils/inlining/Inliner.scala
@@ -273,13 +273,21 @@ object Inliner {
               indirectMethods = methods.map { case (name, info) =>
                 (
                   name,
-                  MethodInfoForAnalysis(body = info.body, depth = info.depth)
+                  MethodInfoForAnalysis(
+                    selfArgName = info.selfArgName,
+                    body = info.body,
+                    depth = info.depth
+                  )
                 )
               },
               allMethods = allMethods.map { case (name, info) =>
                 (
                   name,
-                  MethodInfoForAnalysis(body = info.body, depth = info.depth)
+                  MethodInfoForAnalysis(
+                    selfArgName = info.selfArgName,
+                    body = info.body,
+                    depth = info.depth
+                  )
                 )
               }
             ),

--- a/analysis/src/main/scala/org/polystat/odin/analysis/utils/inlining/LocateCalls.scala
+++ b/analysis/src/main/scala/org/polystat/odin/analysis/utils/inlining/LocateCalls.scala
@@ -28,14 +28,11 @@ object LocateCalls {
       case _ => false
     }
 
-  def hasSelfAsFirstParam(params: Vector[LazyName]): Boolean =
-    params.headOption.exists(_.name == "self")
-
   def parseMethod(
     methodBnd: EOBndExpr[EOExprOnly],
     bndDepth: BigInt
   ): Option[MethodInfo] = {
-    def findCalls(body: EOObj[EOExprOnly]): Vector[Call] = {
+    def findCalls(selfArg: String, body: EOObj[EOExprOnly]): Vector[Call] = {
       def findCallsRec(
         subExpr: Fix[EOExpr],
         pathToCallSite: PathToCallSite,
@@ -45,12 +42,14 @@ object LocateCalls {
         Fix.un(subExpr) match {
           // the call was found
           case EOCopy(
-                 Fix(EODot(Fix(EOSimpleAppWithLocator("self", locator)), name)),
+                 Fix(
+                   EODot(Fix(EOSimpleAppWithLocator(srcName, locator)), name)
+                 ),
                  args
-               ) if locator == depth =>
+               ) if locator == depth && srcName == selfArg =>
             val firstArgIsValid: Boolean = args.head match {
-              case EOAnonExpr(EOSimpleAppWithLocator("self", locator))
-                   if locator == depth => true
+              case EOAnonExpr(EOSimpleAppWithLocator(firstArg, locator))
+                   if locator == depth && firstArg == selfArg => true
               case _ => false
             }
             if (firstArgIsValid)
@@ -138,11 +137,17 @@ object LocateCalls {
     }
 
     Fix.un(methodBnd.expr) match {
-      case obj @ EOObj(params, _, bndAttrs)
-           if hasSelfAsFirstParam(params) &&
-           hasPhiAttribute(bndAttrs) &&
+      case obj @ EOObj(selfArg +: _, _, bndAttrs)
+           if hasPhiAttribute(bndAttrs) &&
            hasNoReferencesToPhi(bndAttrs) =>
-        Some(MethodInfo(findCalls(obj), obj, bndDepth))
+        Some(
+          MethodInfo(
+            selfArgName = selfArg.name,
+            calls = findCalls(selfArg.name, obj),
+            body = obj,
+            depth = bndDepth
+          )
+        )
       case _ => None
     }
   }

--- a/analysis/src/main/scala/org/polystat/odin/analysis/utils/inlining/package.scala
+++ b/analysis/src/main/scala/org/polystat/odin/analysis/utils/inlining/package.scala
@@ -103,6 +103,7 @@ object ObjectInfo {
 }
 
 final case class MethodInfoForAnalysis(
+  selfArgName: String,
   body: EOObj[EOExprOnly],
   depth: BigInt
 )

--- a/analysis/src/main/scala/org/polystat/odin/analysis/utils/inlining/package.scala
+++ b/analysis/src/main/scala/org/polystat/odin/analysis/utils/inlining/package.scala
@@ -165,6 +165,7 @@ final case class ParentInfoForInlining[M](
 sealed trait GenericMethodInfo
 
 final case class MethodInfo(
+  selfArgName: String,
   calls: Vector[Call],
   body: EOObj[EOExprOnly],
   depth: BigInt,

--- a/analysis/src/test/resources/mutualrec/with_recursion/3rd_defect.eo
+++ b/analysis/src/test/resources/mutualrec/with_recursion/3rd_defect.eo
@@ -5,13 +5,13 @@
       seq > @
         assert (0.less y1)
         x
-    [self y] > g
-      self.h self y > @
-    [self z] > h
+    [this y] > g
+      this.h this y > @
+    [this z] > h
       z > @
   [] > child
     parent > @
     [self y] > f
       y > @
-    [self z] > h
-      self.g self z > @
+    [this z] > h
+      this.g this z > @

--- a/analysis/src/test/resources/mutualrec/with_recursion/mutual_rec_somewhere.eo
+++ b/analysis/src/test/resources/mutualrec/with_recursion/mutual_rec_somewhere.eo
@@ -1,18 +1,16 @@
 [] > a
   memory > x
-  [self] > inc
-    self.x.write (self.x.add 1) > @
+  [this] > inc
+    this.x.write (this.x.add 1) > @
 
 [] > b
   a > @
-  [self] > f
-    self.g self > @
+  [this] > f
+    this.g this > @
   [self] > g
     self > @
 
 [] > c
   b > @
-  [self] > g
-    self.f self > @
-
-
+  [this] > g
+    this.f this > @

--- a/analysis/src/test/resources/mutualrec/with_recursion/realistic.eo
+++ b/analysis/src/test/resources/mutualrec/with_recursion/realistic.eo
@@ -3,15 +3,15 @@
 [] > a
   [] > new
     b.new > @
-    [self x y] > f
-      self.g self y x > @
+    [this x y] > f
+      this.g this y x > @
 
 [] > b
   [] > new
     c.new > @
 [] > c
   [] > new
-    [self y x] > g
-      self.f self x y > @
-    [self x y] > f
-      self > @
+    [slf y x] > g
+      slf.f slf x y > @
+    [this x y] > f
+      this > @

--- a/analysis/src/test/scala/org/polystat/odin/analysis/DetectStateAccessTests.scala
+++ b/analysis/src/test/scala/org/polystat/odin/analysis/DetectStateAccessTests.scala
@@ -292,8 +292,8 @@ class DetectStateAccessTests extends AnyWordSpec {
                |  memory > state
                |[] > child
                |  parent > @
-               |  [self] > method
-               |    self.state.add 10 > @
+               |  [this] > method
+               |    this.state.add 10 > @
                |""".stripMargin,
       expected = List(
         "Method 'method' of object 'child' directly accesses state 'state' of base class 'parent'",
@@ -306,8 +306,8 @@ class DetectStateAccessTests extends AnyWordSpec {
                |  memory > state
                |[] > child
                |  parent > @
-               |  [self] > method
-               |    (self.state.add 10).write 4 > @
+               |  [this] > method
+               |    (this.state.add 10).write 4 > @
                |""".stripMargin,
       expected = List(
         "Method 'method' of object 'child' directly accesses state 'state' of base class 'parent'",
@@ -320,8 +320,8 @@ class DetectStateAccessTests extends AnyWordSpec {
                |  memory > state
                |[] > child
                |  parent > @
-               |  [self] > method
-               |    3.sub ((self.state.add 10).add 10) > @
+               |  [slf] > method
+               |    3.sub ((slf.state.add 10).add 10) > @
                |""".stripMargin,
       expected = List(
         "Method 'method' of object 'child' directly accesses state 'state' of base class 'parent'",
@@ -359,9 +359,9 @@ class DetectStateAccessTests extends AnyWordSpec {
                |    self.state.write new_state > @
                |[] > b
                |  a > @
-               |  [self new_state] > change_state_plus_two
+               |  [this new_state] > change_state_plus_two
                |    new_state.add 2 > tmp
-               |    self.update_state self tmp > @
+               |    this.update_state this tmp > @
                |""".stripMargin,
       expected = List()
     ),

--- a/analysis/src/test/scala/org/polystat/odin/analysis/LiskovPrincipleTests.scala
+++ b/analysis/src/test/scala/org/polystat/odin/analysis/LiskovPrincipleTests.scala
@@ -91,14 +91,14 @@ class LiskovPrincipleTests extends AnyWordSpec {
         """
           |[] > test
           |  [] > parent
-          |    [self x] > f
+          |    [this_self_is_not_used x] > f
           |      x > @
-          |    [self x] > g
-          |      self.f self x > @
+          |    [this x] > g
+          |      this.f this x > @
           |
           |  [] > child
           |    test.parent > @
-          |    [self y] > f
+          |    [slf y] > f
           |      10.div y > @
           |""".stripMargin,
       expected = List(
@@ -113,17 +113,17 @@ class LiskovPrincipleTests extends AnyWordSpec {
         """
           |[] > test
           |  [] > grandparent
-          |    [self x] > a
+          |    [this x] > a
           |      10 > @
-          |    [self x] > b
-          |      self.a self x > @
+          |    [this x] > b
+          |      this.a this x > @
           |
           |  [] > parent
           |    test.grandparent > @
           |    [self x] > f
           |      x > @
-          |    [self x] > g
-          |      self.f self x > @
+          |    [this x] > g
+          |      this.f this x > @
           |
           |  [] > child
           |    test.parent > @
@@ -176,8 +176,8 @@ class LiskovPrincipleTests extends AnyWordSpec {
           |  [] > base
           |    [self v] > n
           |      2 > @
-          |    [self v] > m
-          |      self.n self v > @
+          |    [slf v] > m
+          |      slf.n slf v > @
           |  [] > derived
           |    base > @
           |    [self v] > n

--- a/analysis/src/test/scala/org/polystat/odin/analysis/LocateCallsTests.scala
+++ b/analysis/src/test/scala/org/polystat/odin/analysis/LocateCallsTests.scala
@@ -1,0 +1,96 @@
+package org.polystat.odin.analysis
+
+import cats.data.NonEmptyVector
+import higherkindness.droste.data.Fix
+import org.polystat.odin.analysis.utils.inlining.LocateCalls
+import org.polystat.odin.core.ast._
+import org.polystat.odin.core.ast.astparams._
+import org.scalatest.wordspec.AnyWordSpec
+
+class LocateCallsTests extends AnyWordSpec {
+
+  private case class TestCase(
+    label: String,
+    methodBody: EOBndExpr[EOExprOnly],
+    expected: Set[String]
+  )
+
+  private def runTestCase(test: TestCase): Unit = {
+    test match {
+      case TestCase(label, methodBody, expected) =>
+        registerTest(label) {
+          val parsed = LocateCalls.parseMethod(methodBody, 0)
+          parsed match {
+            case None => fail("LocateCalls.parseMethods returned None!")
+            case Some(parsed) =>
+              assert(parsed.calls.map(_.methodName).toSet == expected)
+          }
+        }
+    }
+  }
+
+  def simpleMethod(
+    name: String,
+    calledMethods: NonEmptyVector[String],
+    selfArg: String,
+  ): EOBndExpr[EOExprOnly] = EOBndExpr(
+    bndName = EOAnyNameBnd(LazyName(name)),
+    Fix(
+      EOObj(
+        freeAttrs = Vector(LazyName(selfArg)),
+        varargAttr = None,
+        bndAttrs = Vector(
+          EOBndExpr(
+            EODecoration,
+            Fix(
+              EOCopy(
+                Fix[EOExpr](EOSimpleAppWithLocator("seq", 1)),
+                calledMethods.map(name =>
+                  EOAnonExpr(
+                    Fix(
+                      EOCopy(
+                        Fix(
+                          EODot(
+                            Fix[EOExpr](EOSimpleAppWithLocator(selfArg, 0)),
+                            name,
+                          )
+                        ),
+                        NonEmptyVector.one(
+                          EOAnonExpr(
+                            Fix[EOExpr](EOSimpleAppWithLocator(selfArg, 0))
+                          )
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+
+  private val testCases: List[TestCase] = List(
+    "this",
+    "self",
+    "asd",
+    "anything"
+  ).map(selfArg =>
+    TestCase(
+      label = s"method with $selfArg",
+      methodBody = simpleMethod(
+        name = "f",
+        calledMethods = NonEmptyVector.one("g"),
+        selfArg = selfArg
+      ),
+      expected = Set("g")
+    )
+  ).appendedAll(
+    List()
+  )
+
+  testCases.foreach(runTestCase)
+
+}

--- a/analysis/src/test/scala/org/polystat/odin/analysis/UnjustifiedAssumptionTests.scala
+++ b/analysis/src/test/scala/org/polystat/odin/analysis/UnjustifiedAssumptionTests.scala
@@ -151,10 +151,10 @@ class UnjustifiedAssumptionTests extends AnyWordSpec {
           |      seq > @
           |        assert (0.less y1)
           |        x
-          |    [self y] > g
-          |      self.f self y > @
-          |    [self y] > g2
-          |      self.f self y > @
+          |    [this y] > g
+          |      this.f this y > @
+          |    [hahaha_this_is_self y] > g2
+          |      hahaha_this_is_self.f hahaha_this_is_self y > @
           |    [self z] > h
           |      z > @
           |  [] > child
@@ -185,11 +185,11 @@ class UnjustifiedAssumptionTests extends AnyWordSpec {
           |        assert (0.less t)
           |        x
           |
-          |    [self y2] > gg
-          |      self.g self y2 > @
+          |    [this y2] > gg
+          |      this.g this y2 > @
           |
-          |    [self y3] > ggg
-          |      self.gg self y3 > @
+          |    [this y3] > ggg
+          |      this.gg this y3 > @
           |
           |    [self z] > h
           |      z > @
@@ -197,8 +197,8 @@ class UnjustifiedAssumptionTests extends AnyWordSpec {
           |    test.parent > @
           |    [self y] > f
           |      y > @
-          |    [self z] > h
-          |      self.ggg self z > @
+          |    [slf z] > h
+          |      slf.ggg slf z > @
           |""".stripMargin,
       expected = List(
         "Method g is not referentially transparent",
@@ -213,10 +213,10 @@ class UnjustifiedAssumptionTests extends AnyWordSpec {
       code =
         """[] > test
           |  [] > base
-          |    [self v] > n
+          |    [this v] > n
           |      2 > @
-          |    [self v] > m
-          |      self.n self v > @
+          |    [this v] > m
+          |      this.n this v > @
           |  [] > derived
           |    base > @
           |    [self v] > n


### PR DESCRIPTION
This pull request allows the definition of methods and method calls in the following way:
1. with self (the previous one) 
```
[self] > f
  self.g self > @
```
2. with this:
```
[this] > f
  this.g this > @
```
3. with any other name:
```
[slf] > f
  slf.g slf > @
```