### PR TITLE
Revisiting direct state access analyzer

### DIFF
--- a/analysis/src/main/scala/org/polystat/odin/analysis/stateaccess/DetectStateAccess.scala
+++ b/analysis/src/main/scala/org/polystat/odin/analysis/stateaccess/DetectStateAccess.scala
@@ -103,7 +103,7 @@ object DetectStateAccess {
         // TODO: add a proper depth check
         case EOSimpleAppWithLocator(dotSrc, x)
              if x == depth && dotSrc == selfArgName => true
-        case innerDot @ EODot(_, _) => hasSelfAsSource(innerDot)
+        case innerDot @ EODot(_, _) => hasSelfAsSource(innerDot, depth)
         case _ => false
       }
     }
@@ -111,8 +111,8 @@ object DetectStateAccess {
     def buildDotChain(dot: EODot[EOExprOnly]): List[String] =
       Fix.un(dot.src) match {
         // TODO: add depth check???
-        case EOSimpleAppWithLocator(argName, _)
-             if argName == selfArgName => List()
+        case EOSimpleAppWithLocator(argName, _) if argName == selfArgName =>
+          List()
         case innerDot @ EODot(_, _) =>
           buildDotChain(innerDot).appended(innerDot.name)
         case _ => List()

--- a/analysis/src/main/scala/org/polystat/odin/analysis/stateaccess/DetectStateAccess.scala
+++ b/analysis/src/main/scala/org/polystat/odin/analysis/stateaccess/DetectStateAccess.scala
@@ -14,7 +14,7 @@ object DetectStateAccess {
   type ObjInfo = ObjectInfo[ParentInfo[MethodInfo, ObjectInfo], MethodInfo]
 
   case class State(
-    containerName: String,
+    container: ObjInfo,
     statePath: List[String],
     states: Vector[EONamedBnd]
   )
@@ -25,7 +25,7 @@ object DetectStateAccess {
     statePath: List[String]
   )
 
-  def collectNestedStates(mainParent: String)(
+  def collectNestedStates(mainParent: ObjInfo)(
     subTree: Inliner.CompleteObjectTree,
     depth: Int
   ): Vector[State] = {
@@ -60,7 +60,6 @@ object DetectStateAccess {
     currentParentLink match {
       case Some(parentLink) =>
         val parentObj = parentLink.linkToParent.getOption(tree).get
-        val currentObjName = parentObj.info.name.name.name
         val currentLvlStateNames = parentObj
           .info
           .bnds
@@ -74,11 +73,11 @@ object DetectStateAccess {
               bndName
           }
         val currentLvlState =
-          State(currentObjName, List(), currentLvlStateNames)
+          State(parentObj.info, List(), currentLvlStateNames)
         val nestedStates = parentObj
           .children
           .flatMap(c =>
-            collectNestedStates(parentObj.info.name.name.name)(
+            collectNestedStates(parentObj.info)(
               c._2,
               parentObj.info.depth.toInt + 1
             )
@@ -97,17 +96,19 @@ object DetectStateAccess {
 
   def getAccessedStates(method: (EONamedBnd, MethodInfo)): List[StateChange] = {
     @tailrec
-    def hasSelfAsSource(dot: EODot[EOExprOnly]): Boolean = {
+    def hasSelfAsSource(dot: EODot[EOExprOnly], depth: BigInt): Boolean = {
       Fix.un(dot.src) match {
-        case EOSimpleAppWithLocator("self", x) if x == 0 => true
-        case innerDot @ EODot(_, _) => hasSelfAsSource(innerDot)
+        // TODO: add a proper depth check
+        case EOSimpleAppWithLocator("self", x) if x == depth => true
+        case innerDot @ EODot(_, _) => hasSelfAsSource(innerDot, depth)
         case _ => false
       }
     }
 
     def buildDotChain(dot: EODot[EOExprOnly]): List[String] =
       Fix.un(dot.src) match {
-        case EOSimpleAppWithLocator("self", x) if x == 0 => List()
+        // TODO: add depth check???
+        case EOSimpleAppWithLocator("self", _) => List()
         case innerDot @ EODot(_, _) =>
           buildDotChain(innerDot).appended(innerDot.name)
         case _ => List()
@@ -125,12 +126,14 @@ object DetectStateAccess {
       List(StateChange(method._1, stateName, containerChain))
     }
 
-    Abstract.foldAst[List[StateChange]](binds) {
-      case EOCopy(Fix(dot @ EODot(Fix(innerDot @ EODot(_, state)), _)), _)
-           if hasSelfAsSource(dot) =>
+    Abstract.foldAst[List[StateChange]](binds, 0) {
+      case (
+             EOCopy(Fix(dot @ EODot(Fix(innerDot @ EODot(_, state)), _)), _),
+             depth
+           ) if hasSelfAsSource(dot, depth) =>
         processDot(innerDot, state)
 
-      case dot @ EODot(_, state) if hasSelfAsSource(dot) =>
+      case (dot @ EODot(_, state), depth) if hasSelfAsSource(dot, depth) =>
         processDot(dot, state)
     }
   }
@@ -148,9 +151,9 @@ object DetectStateAccess {
       } yield
         if (changedStates.contains(state) && statePath == accessedStatePath) {
           val objName = obj._2.info.fqn.names.toList.mkString(".")
-          val stateName = state.name.name
+          val stateName = statePath.appended(state.name.name).mkString(".")
           val method = targetMethod.name.name
-          val container = statePath.prepended(baseClass).mkString(".")
+          val container = baseClass.fqn.show
 
           List(
             f"Method '$method' of object '$objName' directly accesses state '$stateName' of base class '$container'"

--- a/analysis/src/main/scala/org/polystat/odin/analysis/utils/Abstract.scala
+++ b/analysis/src/main/scala/org/polystat/odin/analysis/utils/Abstract.scala
@@ -60,24 +60,25 @@ object Abstract {
   }
 
   def foldAst[A: Monoid](
-    binds: Vector[EOBnd[EOExprOnly]]
-  )(f: PartialFunction[EOExpr[EOExprOnly], A]): A = {
-    def recurse(bnd: EOBnd[EOExprOnly]): A = {
-      f.lift(Fix.un(bnd.expr)) match {
+    binds: Vector[EOBnd[EOExprOnly]],
+    initialDepth: BigInt
+  )(f: PartialFunction[(EOExpr[EOExprOnly], BigInt), A]): A = {
+    def recurse(depth : BigInt)(bnd: EOBnd[EOExprOnly]): A = {
+      f.lift((Fix.un(bnd.expr), depth)) match {
         case Some(value) => value
         case None => Fix.un(bnd.expr) match {
-            case EOObj(_, _, bndAttrs) => bndAttrs.foldMap(recurse)
+            case EOObj(_, _, bndAttrs) => bndAttrs.foldMap(recurse(depth+1))
             case EOCopy(trg, args) =>
-              recurse(EOAnonExpr(trg)).combine(
-                args.foldMap(recurse)
+              recurse(depth)(EOAnonExpr(trg)).combine(
+                args.foldMap(recurse(depth))
               )
-            case EODot(trg, _) => recurse(EOAnonExpr(trg))
-            case EOArray(elems) => elems.foldMap(recurse)
+            case EODot(trg, _) => recurse(depth)(EOAnonExpr(trg))
+            case EOArray(elems) => elems.foldMap(recurse(depth))
             case _ => Monoid[A].empty
           }
       }
     }
-    binds.foldMap(recurse)
+    binds.foldMap(recurse(initialDepth))
   }
 
 }

--- a/analysis/src/main/scala/org/polystat/odin/analysis/utils/Abstract.scala
+++ b/analysis/src/main/scala/org/polystat/odin/analysis/utils/Abstract.scala
@@ -63,11 +63,11 @@ object Abstract {
     binds: Vector[EOBnd[EOExprOnly]],
     initialDepth: BigInt
   )(f: PartialFunction[(EOExpr[EOExprOnly], BigInt), A]): A = {
-    def recurse(depth : BigInt)(bnd: EOBnd[EOExprOnly]): A = {
+    def recurse(depth: BigInt)(bnd: EOBnd[EOExprOnly]): A = {
       f.lift((Fix.un(bnd.expr), depth)) match {
         case Some(value) => value
         case None => Fix.un(bnd.expr) match {
-            case EOObj(_, _, bndAttrs) => bndAttrs.foldMap(recurse(depth+1))
+            case EOObj(_, _, bndAttrs) => bndAttrs.foldMap(recurse(depth + 1))
             case EOCopy(trg, args) =>
               recurse(depth)(EOAnonExpr(trg)).combine(
                 args.foldMap(recurse(depth))

--- a/analysis/src/main/scala/org/polystat/odin/analysis/utils/inlining/LocateCalls.scala
+++ b/analysis/src/main/scala/org/polystat/odin/analysis/utils/inlining/LocateCalls.scala
@@ -19,7 +19,9 @@ object LocateCalls {
       override def combine(x: Boolean, y: Boolean): Boolean = x && y
     }
 
-    foldAst[Boolean](binds) { case EOSimpleAppWithLocator("@", _) => false }
+    foldAst[Boolean](binds, 0) { case (EOSimpleAppWithLocator("@", _), _) =>
+      false
+    }
   }
 
   def hasPhiAttribute(bnds: Vector[EOBnd[EOExprOnly]]): Boolean =

--- a/analysis/src/test/scala/org/polystat/odin/analysis/DetectStateAccessTests.scala
+++ b/analysis/src/test/scala/org/polystat/odin/analysis/DetectStateAccessTests.scala
@@ -342,7 +342,7 @@ class DetectStateAccessTests extends AnyWordSpec {
         "Method 'method' of object 'child' directly accesses state 'state' of base class 'parent'",
       )
     ),
-        TestCase(
+    TestCase(
       label = "Access to state by simply returning it",
       code = """
                |[] > parent
@@ -397,7 +397,7 @@ class DetectStateAccessTests extends AnyWordSpec {
         "Method 'method' of object 'child' directly accesses state 'state' of base class 'parent'",
       )
     ),
-        TestCase(
+    TestCase(
       label =
         "State access when decorated object is an attribute of the same object, but with transitivity",
       code = """


### PR DESCRIPTION
The following fixes are present in this PR:
1. Adjusted the message to better reflect the location of accessed state and the base object;
**BEFORE:**
```Method 'func' of object 'b' directly accesses state 'hidden_state' of base class 'base.inner_state.very_inner_state'```
**AFTER:**
```Method 'func' of object 'test.b' directly accesses state 'inner_state.very_inner_state.hidden_state' of base class 'test.nested.base'```
2. Fixed a bug which prevented nested state access from being detected.
**EXAMPLE:**
```
[] > parent
  memory > state
[] > child
  parent > @
  [self] > method
    seq > @
      s689401025
    [] > s689401025
      b306980751 > @
    [] > b306980751
      s_r1826699684.add > @
        s_r1769193365
    [] > s_r1826699684
      self.state > @
    [] > s_r1769193365
      5 > @
```
**EXPECTED OUTPUT:**
```Method 'method' of object 'child' directly accesses state 'state' of base class 'parent```