### PR TITLE
J2EO fixes for the Direct state access analyzer

### DIFF
--- a/analysis/src/main/scala/org/polystat/odin/analysis/EOOdinAnalyzer.scala
+++ b/analysis/src/main/scala/org/polystat/odin/analysis/EOOdinAnalyzer.scala
@@ -9,10 +9,10 @@ import org.polystat.odin.analysis.liskov.Analyzer
 import org.polystat.odin.analysis.mutualrec.advanced.Analyzer.analyzeAst
 import org.polystat.odin.analysis.stateaccess.DetectStateAccess
 import org.polystat.odin.analysis.utils.inlining.Inliner
-import org.polystat.odin.core.ast.EOBndExpr
-import org.polystat.odin.core.ast.EOProg
+import org.polystat.odin.core.ast.{EOBndExpr, EOProg}
 import org.polystat.odin.core.ast.astparams.EOExprOnly
 import org.polystat.odin.parser.EoParser
+import org.polystat.odin.analysis.utils.j2eo
 import org.polystat.odin.parser.eo.Parser
 
 trait ASTAnalyzer[F[_]] {
@@ -23,20 +23,10 @@ trait ASTAnalyzer[F[_]] {
 object EOOdinAnalyzer {
 
   private def addPredef(existing: EOProg[EOExprOnly]): EOProg[EOExprOnly] = {
-    val PREDEF = Seq(
-      """
-        |[] > class__Object
-        |  [] > new
-        |    [] > self
-        |  [self] > constructor
-        |    self > @
-        |    [self] > init
-        |      [] > @
-        |  [self] > init
-        |    seq > @
-        |      TRUE
-        |""".stripMargin
-    ).flatMap(code => Parser.parse(code).toOption.get.bnds)
+    val PREDEF = (
+      j2eo.Primitives.all ++ j2eo.Other.all
+    )
+      .flatMap(code => Parser.parse(code).toOption.get.bnds)
       .filterNot(bnd =>
         existing.bnds.collect { case e @ EOBndExpr(_, _) => e }.contains(bnd)
       )

--- a/analysis/src/main/scala/org/polystat/odin/analysis/EOOdinAnalyzer.scala
+++ b/analysis/src/main/scala/org/polystat/odin/analysis/EOOdinAnalyzer.scala
@@ -10,10 +10,11 @@ import org.polystat.odin.analysis.liskov.Analyzer
 import org.polystat.odin.analysis.mutualrec.advanced.Analyzer.analyzeAst
 import org.polystat.odin.analysis.stateaccess.DetectStateAccess
 import org.polystat.odin.analysis.utils.inlining.Inliner
-import org.polystat.odin.core.ast.{EOBndExpr, EOProg}
+import org.polystat.odin.analysis.utils.j2eo
+import org.polystat.odin.core.ast.EOBndExpr
+import org.polystat.odin.core.ast.EOProg
 import org.polystat.odin.core.ast.astparams.EOExprOnly
 import org.polystat.odin.parser.EoParser
-import org.polystat.odin.analysis.utils.j2eo
 import org.polystat.odin.parser.eo.Parser
 
 trait ASTAnalyzer[F[_]] {

--- a/analysis/src/main/scala/org/polystat/odin/analysis/utils/j2eo/Other.scala
+++ b/analysis/src/main/scala/org/polystat/odin/analysis/utils/j2eo/Other.scala
@@ -4,42 +4,6 @@ object Other {
 
   val all: Seq[String] = Seq(
     """
-      |+package stdlib.io
-      |+alias stdlib.lang.class__Object
-      |+alias org.eolang.io.stdout
-      |
-      |[] > class__PrintStream
-      |  class__Object > super
-      |  super > @
-      |
-      |  [] > new
-      |    [] > this
-      |      class__Object.new > super
-      |      super > @
-      |      "class__PrintStream" > className
-      |
-      |      [this] > init
-      |        0 > @
-      |
-      |      [this output] > println
-      |        seq > @
-      |          stdout
-      |            str.
-      |              output.toString
-      |                output
-      |          stdout
-      |            "\n"
-      |
-      |    seq > @
-      |      this
-      |
-      |  [this] > constructor
-      |    seq > @
-      |      this.init
-      |        this
-      |      this
-      |""".stripMargin,
-    """
       |+package stdlib.lang
       |
       |[] > class__Object
@@ -57,163 +21,199 @@ object Other {
       |    seq > @
       |      this
       |
-      |  [this] > constructor
+      |  [self] > constructor
       |    seq > @
       |      this.init
-      |        this
-      |      this
+      |        self
+      |      self
       |""".stripMargin,
-    """
-      |+package stdlib.lang
-      |+alias stdlib.lang.class__Object
-      |+alias org.eolang.txt.sprintf
-      |
-      |[] > class__String
-      |  class__Object > super
-      |  super > @
-      |
-      |  [] > new
-      |    [] > this
-      |      class__Object.new > super
-      |      super > @
-      |      "class__String" > className
-      |
-      |      memory > str
-      |
-      |      [this input_string] > init
-      |        seq > @
-      |          this.str.write
-      |            input_string
-      |
-      |      [this] > toString
-      |        seq > @
-      |          class__String.constructor_3
-      |            class__String.new
-      |            this
-      |
-      |      [right] > write
-      |        seq > @
-      |          ^.str.write
-      |            right.str
-      |          class__String.constructor_3
-      |            class__String.new
-      |            ^
-      |
-      |      [right] > add
-      |        seq > @
-      |          class__String.constructor_2
-      |            class__String.new
-      |            sprintf
-      |              "%s%s"
-      |              ^.str
-      |              str.
-      |                right.toString
-      |                  right
-      |
-      |    seq > @
-      |      this
-      |
-      |  [right] > valueOf
-      |    seq > @
-      |      class__String.constructor_2
-      |        class__String.new
-      |        right.as-string
-      |
-      |  [this] > constructor_1
-      |    seq > @
-      |      this
-      |
-      |  [this target] > constructor_2
-      |    seq > @
-      |      this.init
-      |        this
-      |        target
-      |      this
-      |
-      |  [this another_string] > constructor_3
-      |    seq > @
-      |      this.init
-      |        this
-      |        another_string.str
-      |      this
-      |""".stripMargin,
-    """
-      |+package stdlib.lang
-      |+alias stdlib.lang.class__Object
-      |+alias stdlib.io.class__PrintStream
-      |
-      |[] > class__System
-      |  class__Object > super
-      |  super > @
-      |
-      |  class__PrintStream.constructor > out
-      |    class__PrintStream.new
-      |
-      |  [] > new
-      |    [] > this
-      |      class__Object.new > super
-      |      super > @
-      |      "class__System" > className
-      |
-      |      [this] > init
-      |        0 > @
-      |
-      |    seq > @
-      |      this
-      |
-      |  [this] > constructor
-      |    seq > @
-      |      this.init
-      |        this
-      |      this
-      |""".stripMargin,
-    """
-      |+package stdlib.util
-      |+alias stdlib.lang.class__Object
-      |+alias stdlib.primitives.prim__int
-      |+alias stdlib.primitives.prim__float
-      |
-      |[] > class__Random
-      |  class__Object > super
-      |  super > @
-      |
-      |  [] > new
-      |    [] > this
-      |      class__Object.new > super
-      |      super > @
-      |      "class__Random" > className
-      |
-      |      [this] > init
-      |        0 > @
-      |
-      |      [this] > nextInt
-      |        random > r
-      |        seq > @
-      |          prim__int.constructor_2
-      |            prim__int.new
-      |            as-int.
-      |              sub.
-      |                mul.
-      |                  4294967295.0
-      |                  r
-      |                2147483648.0
-      |
-      |      [this] > nextFloat
-      |        random > r
-      |        seq > @
-      |          prim__float.constructor_2
-      |            prim__float.new
-      |            r
-      |
-      |    seq > @
-      |      this
-      |
-      |  [this] > constructor
-      |    seq > @
-      |      this.init
-      |        this
-      |      this
-      |""".stripMargin,
+//    """
+//      |+package stdlib.io
+//      |+alias stdlib.lang.class__Object
+//      |+alias org.eolang.io.stdout
+//      |
+//      |[] > class__PrintStream
+//      |  class__Object > super
+//      |  super > @
+//      |
+//      |  [] > new
+//      |    [] > this
+//      |      class__Object.new > super
+//      |      super > @
+//      |      "class__PrintStream" > className
+//      |
+//      |      [this] > init
+//      |        0 > @
+//      |
+//      |      [this output] > println
+//      |        seq > @
+//      |          stdout
+//      |            str.
+//      |              output.toString
+//      |                output
+//      |          stdout
+//      |            "\n"
+//      |
+//      |    seq > @
+//      |      this
+//      |
+//      |  [self] > constructor
+//      |    seq > @
+//      |      this.init
+//      |        self
+//      |      self
+//      |""".stripMargin,
+//    """
+//      |+package stdlib.lang
+//      |+alias stdlib.lang.class__Object
+//      |+alias org.eolang.txt.sprintf
+//      |
+//      |[] > class__String
+//      |  class__Object > super
+//      |  super > @
+//      |
+//      |  [] > new
+//      |    [] > this
+//      |      class__Object.new > super
+//      |      super > @
+//      |      "class__String" > className
+//      |
+//      |      memory > str
+//      |
+//      |      [this input_string] > init
+//      |        seq > @
+//      |          this.str.write
+//      |            input_string
+//      |
+//      |      [this] > toString
+//      |        seq > @
+//      |          class__String.constructor_3
+//      |            class__String.new
+//      |            this
+//      |
+//      |      [right] > write
+//      |        seq > @
+//      |          ^.str.write
+//      |            right.str
+//      |          class__String.constructor_3
+//      |            class__String.new
+//      |            ^
+//      |
+//      |      [right] > add
+//      |        seq > @
+//      |          class__String.constructor_2
+//      |            class__String.new
+//      |            sprintf
+//      |              "%s%s"
+//      |              ^.str
+//      |              str.
+//      |                right.toString
+//      |                  right
+//      |
+//      |    seq > @
+//      |      this
+//      |
+//      |  [right] > valueOf
+//      |    seq > @
+//      |      class__String.constructor_2
+//      |        class__String.new
+//      |        right.as-string
+//      |
+//      |  [this] > constructor_1
+//      |    seq > @
+//      |      this
+//      |
+//      |  [this target] > constructor_2
+//      |    seq > @
+//      |      this.init
+//      |        this
+//      |        target
+//      |      this
+//      |
+//      |  [this another_string] > constructor_3
+//      |    seq > @
+//      |      this.init
+//      |        this
+//      |        another_string.str
+//      |      this
+//      |""".stripMargin,
+//    """
+//      |+package stdlib.lang
+//      |+alias stdlib.lang.class__Object
+//      |+alias stdlib.io.class__PrintStream
+//      |
+//      |[] > class__System
+//      |  class__Object > super
+//      |  super > @
+//      |
+//      |  class__PrintStream.constructor > out
+//      |    class__PrintStream.new
+//      |
+//      |  [] > new
+//      |    [] > this
+//      |      class__Object.new > super
+//      |      super > @
+//      |      "class__System" > className
+//      |
+//      |      [this] > init
+//      |        0 > @
+//      |
+//      |    seq > @
+//      |      this
+//      |
+//      |  [this] > constructor
+//      |    seq > @
+//      |      this.init
+//      |        this
+//      |      this
+//      |""".stripMargin,
+//    """
+//      |+package stdlib.util
+//      |+alias stdlib.lang.class__Object
+//      |+alias stdlib.primitives.prim__int
+//      |+alias stdlib.primitives.prim__float
+//      |
+//      |[] > class__Random
+//      |  class__Object > super
+//      |  super > @
+//      |
+//      |  [] > new
+//      |    [] > this
+//      |      class__Object.new > super
+//      |      super > @
+//      |      "class__Random" > className
+//      |
+//      |      [this] > init
+//      |        0 > @
+//      |
+//      |      [this] > nextInt
+//      |        random > r
+//      |        seq > @
+//      |          prim__int.constructor_2
+//      |            prim__int.new
+//      |            as-int.
+//      |              sub.
+//      |                mul.
+//      |                  4294967295.0
+//      |                  r
+//      |                2147483648.0
+//      |
+//      |      [this] > nextFloat
+//      |        random > r
+//      |        seq > @
+//      |          prim__float.constructor_2
+//      |            prim__float.new
+//      |            r
+//      |
+//      |    seq > @
+//      |      this
+//      |
+//      |  [self] > constructor
+//      |    seq > @
+//      |      this.init
+//      |        self
+//      |      self
+//      |""".stripMargin,
   )
 
 }

--- a/analysis/src/main/scala/org/polystat/odin/analysis/utils/j2eo/Other.scala
+++ b/analysis/src/main/scala/org/polystat/odin/analysis/utils/j2eo/Other.scala
@@ -1,0 +1,219 @@
+package org.polystat.odin.analysis.utils.j2eo
+
+object Other {
+
+  val all: Seq[String] = Seq(
+    """
+      |+package stdlib.io
+      |+alias stdlib.lang.class__Object
+      |+alias org.eolang.io.stdout
+      |
+      |[] > class__PrintStream
+      |  class__Object > super
+      |  super > @
+      |
+      |  [] > new
+      |    [] > this
+      |      class__Object.new > super
+      |      super > @
+      |      "class__PrintStream" > className
+      |
+      |      [this] > init
+      |        0 > @
+      |
+      |      [this output] > println
+      |        seq > @
+      |          stdout
+      |            str.
+      |              output.toString
+      |                output
+      |          stdout
+      |            "\n"
+      |
+      |    seq > @
+      |      this
+      |
+      |  [this] > constructor
+      |    seq > @
+      |      this.init
+      |        this
+      |      this
+      |""".stripMargin,
+    """
+      |+package stdlib.lang
+      |
+      |[] > class__Object
+      |  [] > new
+      |    [] > this
+      |      "class__Object" > className
+      |      "OBJECT" > @
+      |
+      |      [this] > init
+      |        0 > @
+      |
+      |      [this] > toString
+      |        "OBJECT" > @
+      |
+      |    seq > @
+      |      this
+      |
+      |  [this] > constructor
+      |    seq > @
+      |      this.init
+      |        this
+      |      this
+      |""".stripMargin,
+    """
+      |+package stdlib.lang
+      |+alias stdlib.lang.class__Object
+      |+alias org.eolang.txt.sprintf
+      |
+      |[] > class__String
+      |  class__Object > super
+      |  super > @
+      |
+      |  [] > new
+      |    [] > this
+      |      class__Object.new > super
+      |      super > @
+      |      "class__String" > className
+      |
+      |      memory > str
+      |
+      |      [this input_string] > init
+      |        seq > @
+      |          this.str.write
+      |            input_string
+      |
+      |      [this] > toString
+      |        seq > @
+      |          class__String.constructor_3
+      |            class__String.new
+      |            this
+      |
+      |      [right] > write
+      |        seq > @
+      |          ^.str.write
+      |            right.str
+      |          class__String.constructor_3
+      |            class__String.new
+      |            ^
+      |
+      |      [right] > add
+      |        seq > @
+      |          class__String.constructor_2
+      |            class__String.new
+      |            sprintf
+      |              "%s%s"
+      |              ^.str
+      |              str.
+      |                right.toString
+      |                  right
+      |
+      |    seq > @
+      |      this
+      |
+      |  [right] > valueOf
+      |    seq > @
+      |      class__String.constructor_2
+      |        class__String.new
+      |        right.as-string
+      |
+      |  [this] > constructor_1
+      |    seq > @
+      |      this
+      |
+      |  [this target] > constructor_2
+      |    seq > @
+      |      this.init
+      |        this
+      |        target
+      |      this
+      |
+      |  [this another_string] > constructor_3
+      |    seq > @
+      |      this.init
+      |        this
+      |        another_string.str
+      |      this
+      |""".stripMargin,
+    """
+      |+package stdlib.lang
+      |+alias stdlib.lang.class__Object
+      |+alias stdlib.io.class__PrintStream
+      |
+      |[] > class__System
+      |  class__Object > super
+      |  super > @
+      |
+      |  class__PrintStream.constructor > out
+      |    class__PrintStream.new
+      |
+      |  [] > new
+      |    [] > this
+      |      class__Object.new > super
+      |      super > @
+      |      "class__System" > className
+      |
+      |      [this] > init
+      |        0 > @
+      |
+      |    seq > @
+      |      this
+      |
+      |  [this] > constructor
+      |    seq > @
+      |      this.init
+      |        this
+      |      this
+      |""".stripMargin,
+    """
+      |+package stdlib.util
+      |+alias stdlib.lang.class__Object
+      |+alias stdlib.primitives.prim__int
+      |+alias stdlib.primitives.prim__float
+      |
+      |[] > class__Random
+      |  class__Object > super
+      |  super > @
+      |
+      |  [] > new
+      |    [] > this
+      |      class__Object.new > super
+      |      super > @
+      |      "class__Random" > className
+      |
+      |      [this] > init
+      |        0 > @
+      |
+      |      [this] > nextInt
+      |        random > r
+      |        seq > @
+      |          prim__int.constructor_2
+      |            prim__int.new
+      |            as-int.
+      |              sub.
+      |                mul.
+      |                  4294967295.0
+      |                  r
+      |                2147483648.0
+      |
+      |      [this] > nextFloat
+      |        random > r
+      |        seq > @
+      |          prim__float.constructor_2
+      |            prim__float.new
+      |            r
+      |
+      |    seq > @
+      |      this
+      |
+      |  [this] > constructor
+      |    seq > @
+      |      this.init
+      |        this
+      |      this
+      |""".stripMargin,
+  )
+
+}

--- a/analysis/src/main/scala/org/polystat/odin/analysis/utils/j2eo/Primitives.scala
+++ b/analysis/src/main/scala/org/polystat/odin/analysis/utils/j2eo/Primitives.scala
@@ -3,90 +3,90 @@ package org.polystat.odin.analysis.utils.j2eo
 object Primitives {
 
   val all: Seq[String] = Seq(
-    """
-      |# inc_pre, dec_pre, inc_post, dec_post, add, sub, mul, div are not precise operators
-      |+package stdlib.primitives
-      |+alias stdlib.primitives.prim__num
-      |
-      |[] > prim__boolean
-      |  prim__num > super
-      |  super > @
-      |
-      |  [] > new
-      |    [] > this
-      |      memory > v
-      |      prim__num.new > super
-      |      super > @
-      |      "prim__boolean" > prim_name
-      |
-      |      [] > as-string
-      |        seq > @
-      |          if.
-      |            ^.v
-      |            "true"
-      |            "false"
-      |
-      |      [right] > write
-      |        seq > @
-      |          ^.v.write
-      |            right.v
-      |          prim__boolean.constructor_3
-      |            prim__boolean.new
-      |            ^
-      |
-      |      [right] > and
-      |        seq > @
-      |          prim__boolean.constructor_2
-      |            prim__boolean.new
-      |            ^.v.and
-      |              right.v
-      |
-      |      [right] > or
-      |        seq > @
-      |          prim__boolean.constructor_2
-      |            prim__boolean.new
-      |            ^.v.or
-      |              right.v
-      |
-      |      [] > not
-      |        seq > @
-      |          prim__boolean.constructor_2
-      |            prim__boolean.new
-      |            ^.v.not
-      |
-      |      [t_s f_s] > if
-      |        seq > @
-      |          if.
-      |            ^.v
-      |            t_s
-      |            f_s
-      |
-      |      [f] > while
-      |        seq > @
-      |          while.
-      |            ^.v
-      |            f
-      |
-      |    seq > @
-      |      this
-      |
-      |  [this] > constructor_1
-      |    seq > @
-      |      super.constructor_1
-      |        this
-      |
-      |  [this target] > constructor_2
-      |    seq > @
-      |      super.constructor_2
-      |        this
-      |        target
-      |
-      |  [this another_num] > constructor_3
-      |    seq > @
-      |      super.constructor_3
-      |        this
-      |        another_num
-      |""".stripMargin,
+//    """
+//      |# inc_pre, dec_pre, inc_post, dec_post, add, sub, mul, div are not precise operators
+//      |+package stdlib.primitives
+//      |+alias stdlib.primitives.prim__num
+//      |
+//      |[] > prim__boolean
+//      |  prim__num > super
+//      |  super > @
+//      |
+//      |  [] > new
+//      |    [] > this
+//      |      memory > v
+//      |      prim__num.new > super
+//      |      super > @
+//      |      "prim__boolean" > prim_name
+//      |
+//      |      [] > as-string
+//      |        seq > @
+//      |          if.
+//      |            ^.v
+//      |            "true"
+//      |            "false"
+//      |
+//      |      [right] > write
+//      |        seq > @
+//      |          ^.v.write
+//      |            right.v
+//      |          prim__boolean.constructor_3
+//      |            prim__boolean.new
+//      |            ^
+//      |
+//      |      [right] > and
+//      |        seq > @
+//      |          prim__boolean.constructor_2
+//      |            prim__boolean.new
+//      |            ^.v.and
+//      |              right.v
+//      |
+//      |      [right] > or
+//      |        seq > @
+//      |          prim__boolean.constructor_2
+//      |            prim__boolean.new
+//      |            ^.v.or
+//      |              right.v
+//      |
+//      |      [] > not
+//      |        seq > @
+//      |          prim__boolean.constructor_2
+//      |            prim__boolean.new
+//      |            ^.v.not
+//      |
+//      |      [t_s f_s] > if
+//      |        seq > @
+//      |          if.
+//      |            ^.v
+//      |            t_s
+//      |            f_s
+//      |
+//      |      [f] > while
+//      |        seq > @
+//      |          while.
+//      |            ^.v
+//      |            f
+//      |
+//      |    seq > @
+//      |      this
+//      |
+//      |  [this] > constructor_1
+//      |    seq > @
+//      |      super.constructor_1
+//      |        this
+//      |
+//      |  [this target] > constructor_2
+//      |    seq > @
+//      |      super.constructor_2
+//      |        this
+//      |        target
+//      |
+//      |  [this another_num] > constructor_3
+//      |    seq > @
+//      |      super.constructor_3
+//      |        this
+//      |        another_num
+//      |""".stripMargin,
     """
       |# inc_pre, dec_pre, inc_post, dec_post, add, sub, mul, div are not precise operators
       |+package stdlib.primitives
@@ -672,7 +672,7 @@ object Primitives {
       |      prim__int.constructor_2
       |        prim__int.new
       |        mod.
-      |          right.integer_part
+      |          this.integer_part
       |            right
       |          max_int
       |
@@ -701,115 +701,7 @@ object Primitives {
       |  [] > new
       |    []> this
       |      memory > v
-      |      "prim__num" > prim_name
-      |      "prim" > @
-      |
-      |      [] > as-string
-      |        seq > @
-      |          ^.v.as-string
-      |
-      |      [this] > integer_part
-      |        seq > @
-      |          if.
-      |            not.
-      |              this.prim_name.eq "prim__boolean"
-      |            if.
-      |              and.
-      |                not.
-      |                  this.prim_name.eq "prim__float"
-      |                not.
-      |                  this.prim_name.eq "prim__double"
-      |              this.v
-      |              this.v.as-int
-      |            if.
-      |              this.v
-      |              1
-      |              0
-      |
-      |      [this] > float_part
-      |        seq > @
-      |          if.
-      |            not.
-      |              this.prim_name.eq "prim__boolean"
-      |            if.
-      |              and.
-      |                not.
-      |                  this.prim_name.eq "prim__float"
-      |                not.
-      |                  this.prim_name.eq "prim__double"
-      |              this.v.as-float
-      |              this.v
-      |            if.
-      |              this.v
-      |              1.0
-      |              0.0
-      |
-      |      [this value] > init
-      |        seq > @
-      |          this.v.write
-      |            value
-      |
-      |      [right] > eq
-      |        seq > @
-      |          prim__boolean.constructor_2
-      |            prim__boolean.new
-      |            ^.v.eq
-      |              right.v
-      |
-      |      [right] > greater
-      |        seq > @
-      |          prim__boolean.constructor_2
-      |            prim__boolean.new
-      |            ^.v.greater
-      |              right.v
-      |
-      |      [right] > less
-      |        seq > @
-      |          prim__boolean.constructor_2
-      |            prim__boolean.new
-      |            ^.v.less
-      |              right.v
-      |
-      |      [right] > geq
-      |        seq > @
-      |          prim__boolean.constructor_2
-      |            prim__boolean.new
-      |            ^.v.geq
-      |              right.v
-      |
-      |      [right] > leq
-      |        seq > @
-      |          prim__boolean.constructor_2
-      |            prim__boolean.new
-      |            ^.v.leq
-      |              right.v
-      |
-      |      [right] > neq
-      |        seq > @
-      |          prim__boolean.constructor_2
-      |            prim__boolean.new
-      |            ^.v.neq
-      |              right.v
-      |
       |    seq > @
-      |      this
-      |
-      |  [this] > constructor_1
-      |    seq > @
-      |      this
-      |
-      |  [this target] > constructor_2
-      |    seq > @
-      |      this.init
-      |        this
-      |        target
-      |      this
-      |
-      |  [this another_num] > constructor_3
-      |    seq > @
-      |      this.init
-      |        this
-      |        another_num.v
       |      this
       |""".stripMargin,
     """

--- a/analysis/src/main/scala/org/polystat/odin/analysis/utils/j2eo/Primitives.scala
+++ b/analysis/src/main/scala/org/polystat/odin/analysis/utils/j2eo/Primitives.scala
@@ -1,0 +1,1055 @@
+package org.polystat.odin.analysis.utils.j2eo
+
+object Primitives {
+
+  val all: Seq[String] = Seq(
+    """
+      |# inc_pre, dec_pre, inc_post, dec_post, add, sub, mul, div are not precise operators
+      |+package stdlib.primitives
+      |+alias stdlib.primitives.prim__num
+      |
+      |[] > prim__boolean
+      |  prim__num > super
+      |  super > @
+      |
+      |  [] > new
+      |    [] > this
+      |      memory > v
+      |      prim__num.new > super
+      |      super > @
+      |      "prim__boolean" > prim_name
+      |
+      |      [] > as-string
+      |        seq > @
+      |          if.
+      |            ^.v
+      |            "true"
+      |            "false"
+      |
+      |      [right] > write
+      |        seq > @
+      |          ^.v.write
+      |            right.v
+      |          prim__boolean.constructor_3
+      |            prim__boolean.new
+      |            ^
+      |
+      |      [right] > and
+      |        seq > @
+      |          prim__boolean.constructor_2
+      |            prim__boolean.new
+      |            ^.v.and
+      |              right.v
+      |
+      |      [right] > or
+      |        seq > @
+      |          prim__boolean.constructor_2
+      |            prim__boolean.new
+      |            ^.v.or
+      |              right.v
+      |
+      |      [] > not
+      |        seq > @
+      |          prim__boolean.constructor_2
+      |            prim__boolean.new
+      |            ^.v.not
+      |
+      |      [t_s f_s] > if
+      |        seq > @
+      |          if.
+      |            ^.v
+      |            t_s
+      |            f_s
+      |
+      |      [f] > while
+      |        seq > @
+      |          while.
+      |            ^.v
+      |            f
+      |
+      |    seq > @
+      |      this
+      |
+      |  [this] > constructor_1
+      |    seq > @
+      |      super.constructor_1
+      |        this
+      |
+      |  [this target] > constructor_2
+      |    seq > @
+      |      super.constructor_2
+      |        this
+      |        target
+      |
+      |  [this another_num] > constructor_3
+      |    seq > @
+      |      super.constructor_3
+      |        this
+      |        another_num
+      |""".stripMargin,
+    """
+      |# inc_pre, dec_pre, inc_post, dec_post, add, sub, mul, div are not precise operators
+      |+package stdlib.primitives
+      |+alias stdlib.primitives.prim__num
+      |
+      |[] > prim__byte
+      |  prim__num > super
+      |  super > @
+      |
+      |  [] > new
+      |    [] > this
+      |      memory > v
+      |      prim__num.new > super
+      |      super > @
+      |      "prim__byte" > prim_name
+      |
+      |      [] > inc_pre
+      |        seq > @
+      |          ^.v.write
+      |            ^.v.add
+      |              1
+      |          prim__byte.constructor_3
+      |            prim__byte.new
+      |            ^
+      |
+      |      [] > dec_pre
+      |        seq > @
+      |          ^.v.write
+      |            ^.v.sub
+      |              1
+      |          prim__byte.constructor_3
+      |            prim__byte.new
+      |            ^
+      |
+      |      [] > inc_post
+      |        prim__byte.constructor_1 > old
+      |          prim__byte.new
+      |        seq > @
+      |          old.v.write
+      |            ^.v
+      |          ^.v.write
+      |            ^.v.add
+      |              1
+      |          old
+      |
+      |      [] > dec_post
+      |        prim__byte.constructor_1 > old
+      |          prim__byte.new
+      |        seq > @
+      |          old.v.write
+      |            ^.v
+      |          ^.v.write
+      |            ^.v.sub
+      |              1
+      |          old
+      |
+      |      [right] > write
+      |        seq > @
+      |          ^.v.write
+      |            right.v
+      |          prim__byte.constructor_3
+      |            prim__byte.new
+      |            ^
+      |
+      |      [right] > add
+      |        seq > @
+      |          prim__byte.constructor_2
+      |            prim__byte.new
+      |            ^.v.add
+      |              right.v
+      |
+      |      [right] > sub
+      |        seq > @
+      |          prim__byte.constructor_2
+      |            prim__byte.new
+      |            ^.v.sub
+      |              right.v
+      |
+      |      [right] > mul
+      |        seq > @
+      |          prim__byte.constructor_2
+      |            prim__byte.new
+      |            ^.v.mul
+      |              right.v
+      |
+      |      [right] > div
+      |        seq > @
+      |          prim__byte.constructor_2
+      |            prim__byte.new
+      |            ^.v.div
+      |              right.v
+      |
+      |      [right] > mod
+      |        seq > @
+      |          prim__byte.constructor_2
+      |            prim__byte.new
+      |            ^.v.mod
+      |              right.v
+      |
+      |    seq > @
+      |      this
+      |
+      |  [this] > constructor_1
+      |    seq > @
+      |      super.constructor_1
+      |        this
+      |
+      |  [this target] > constructor_2
+      |    seq > @
+      |      super.constructor_2
+      |        this
+      |        target
+      |
+      |  [this another_num] > constructor_3
+      |    seq > @
+      |      super.constructor_3
+      |        this
+      |        another_num
+      |""".stripMargin,
+    """
+      |# inc_pre, dec_pre, inc_post, dec_post, add, sub, mul, div are not precise operators
+      |+package stdlib.primitives
+      |+alias stdlib.primitives.prim__num
+      |
+      |[] > prim__char
+      |  prim__num > super
+      |  super > @
+      |
+      |  [] > new
+      |    [] > this
+      |      memory > v
+      |      prim__num.new > super
+      |      super > @
+      |      "prim__char" > prim_name
+      |
+      |      [] > inc_pre
+      |        seq > @
+      |          ^.v.write
+      |            ^.v.add
+      |              1
+      |          prim__char.constructor_3
+      |            prim__char.new
+      |            ^
+      |
+      |      [] > dec_pre
+      |        seq > @
+      |          ^.v.write
+      |            ^.v.sub
+      |              1
+      |          prim__char.constructor_3
+      |            prim__char.new
+      |            ^
+      |
+      |      [] > inc_post
+      |        prim__char.constructor_1 > old
+      |          prim__char.new
+      |        seq > @
+      |          old.v.write
+      |            ^.v
+      |          ^.v.write
+      |            ^.v.add
+      |              1
+      |          old
+      |
+      |      [] > dec_post
+      |        prim__char.constructor_1 > old
+      |          prim__char.new
+      |        seq > @
+      |          old.v.write
+      |            ^.v
+      |          ^.v.write
+      |            ^.v.sub
+      |              1
+      |          old
+      |
+      |      [right] > write
+      |        seq > @
+      |          ^.v.write
+      |            right.v
+      |          prim__char.constructor_3
+      |            prim__char.new
+      |            ^
+      |
+      |      [right] > add
+      |        seq > @
+      |          prim__char.constructor_2
+      |            prim__char.new
+      |            ^.v.add
+      |              right.v
+      |
+      |      [right] > sub
+      |        seq > @
+      |          prim__char.constructor_2
+      |            prim__char.new
+      |            ^.v.sub
+      |              right.v
+      |
+      |      [right] > mul
+      |        seq > @
+      |          prim__char.constructor_2
+      |            prim__char.new
+      |            ^.v.mul
+      |              right.v
+      |
+      |      [right] > div
+      |        seq > @
+      |          prim__char.constructor_2
+      |            prim__char.new
+      |            ^.v.div
+      |              right.v
+      |
+      |      [right] > mod
+      |        seq > @
+      |          prim__char.constructor_2
+      |            prim__char.new
+      |            ^.v.mod
+      |              right.v
+      |
+      |    seq > @
+      |      this
+      |
+      |  [this] > constructor_1
+      |    seq > @
+      |      super.constructor_1
+      |        this
+      |
+      |  [this target] > constructor_2
+      |    seq > @
+      |      super.constructor_2
+      |        this
+      |        target
+      |
+      |  [this another_num] > constructor_3
+      |    seq > @
+      |      super.constructor_3
+      |        this
+      |        another_num
+      |""".stripMargin,
+    """
+      |# inc_pre, dec_pre, inc_post, dec_post, add, sub, mul, div are not precise operators
+      |+package stdlib.primitives
+      |+alias stdlib.primitives.prim__num
+      |
+      |[] > prim__double
+      |  prim__num > super
+      |  super > @
+      |
+      |  [] > new
+      |    [] > this
+      |      memory > v
+      |      prim__num.new > super
+      |      super > @
+      |      "prim__double" > prim_name
+      |
+      |      [] > inc_pre
+      |        seq > @
+      |          ^.v.write
+      |            ^.v.add
+      |              1
+      |          prim__double.constructor_3
+      |            prim__double.new
+      |            ^
+      |
+      |      [] > dec_pre
+      |        seq > @
+      |          ^.v.write
+      |            ^.v.sub
+      |              1
+      |          prim__double.constructor_3
+      |            prim__double.new
+      |            ^
+      |
+      |      [] > inc_post
+      |        prim__double.constructor_1 > old
+      |          prim__double.new
+      |        seq > @
+      |          old.v.write
+      |            ^.v
+      |          ^.v.write
+      |            ^.v.add
+      |              1
+      |          old
+      |
+      |      [] > dec_post
+      |        prim__double.constructor_1 > old
+      |          prim__double.new
+      |        seq > @
+      |          old.v.write
+      |            ^.v
+      |          ^.v.write
+      |            ^.v.sub
+      |              1
+      |          old
+      |
+      |      [right] > write
+      |        seq > @
+      |          ^.v.write
+      |            right.v
+      |          prim__double.constructor_3
+      |            prim__double.new
+      |            ^
+      |
+      |      [right] > add
+      |        seq > @
+      |          prim__double.constructor_2
+      |            prim__double.new
+      |            ^.v.add
+      |              right.v
+      |
+      |      [right] > sub
+      |        seq > @
+      |          prim__double.constructor_2
+      |            prim__double.new
+      |            ^.v.sub
+      |              right.v
+      |
+      |      [right] > mul
+      |        seq > @
+      |          prim__double.constructor_2
+      |            prim__double.new
+      |            ^.v.mul
+      |              right.v
+      |
+      |      [right] > div
+      |        seq > @
+      |          prim__double.constructor_2
+      |            prim__double.new
+      |            ^.v.div
+      |              right.v
+      |
+      |      [right] > mod
+      |        seq > @
+      |          prim__double.constructor_2
+      |            prim__double.new
+      |            ^.v.mod
+      |              right.v
+      |
+      |    seq > @
+      |      this
+      |
+      |  [this] > constructor_1
+      |    seq > @
+      |      super.constructor_1
+      |        this
+      |
+      |  [this target] > constructor_2
+      |    seq > @
+      |      super.constructor_2
+      |        this
+      |        target
+      |
+      |  [this another_num] > constructor_3
+      |    seq > @
+      |      super.constructor_3
+      |        this
+      |        another_num
+      |""".stripMargin,
+    """
+      |# inc_pre, dec_pre, inc_post, dec_post, add, sub, mul, div are not precise operators
+      |+package stdlib.primitives
+      |+alias stdlib.primitives.prim__num
+      |
+      |[] > prim__float
+      |  prim__num > super
+      |  super > @
+      |
+      |  [] > new
+      |    [] > this
+      |      memory > v
+      |      prim__num.new > super
+      |      super > @
+      |      "prim__float" > prim_name
+      |
+      |      [] > inc_pre
+      |        seq > @
+      |          ^.v.write
+      |            ^.v.add
+      |              1
+      |          prim__float.constructor_3
+      |            prim__float.new
+      |            ^
+      |
+      |      [] > dec_pre
+      |        seq > @
+      |          ^.v.write
+      |            ^.v.sub
+      |              1
+      |          prim__float.constructor_3
+      |            prim__float.new
+      |            ^
+      |
+      |      [] > inc_post
+      |        prim__float.constructor_1 > old
+      |          prim__float.new
+      |        seq > @
+      |          old.v.write
+      |            ^.v
+      |          ^.v.write
+      |            ^.v.add
+      |              1
+      |          old
+      |
+      |      [] > dec_post
+      |        prim__float.constructor_1 > old
+      |          prim__float.new
+      |        seq > @
+      |          old.v.write
+      |            ^.v
+      |          ^.v.write
+      |            ^.v.sub
+      |              1
+      |          old
+      |
+      |      [right] > write
+      |        seq > @
+      |          ^.v.write
+      |            right.v
+      |          prim__float.constructor_3
+      |            prim__float.new
+      |            ^
+      |
+      |      [right] > add
+      |        seq > @
+      |          prim__float.constructor_2
+      |            prim__float.new
+      |            ^.v.add
+      |              right.v
+      |
+      |      [right] > sub
+      |        seq > @
+      |          prim__float.constructor_2
+      |            prim__float.new
+      |            ^.v.sub
+      |              right.v
+      |
+      |      [right] > mul
+      |        seq > @
+      |          prim__float.constructor_2
+      |            prim__float.new
+      |            ^.v.mul
+      |              right.v
+      |
+      |      [right] > div
+      |        seq > @
+      |          prim__float.constructor_2
+      |            prim__float.new
+      |            ^.v.div
+      |              right.v
+      |
+      |      [right] > mod
+      |        seq > @
+      |          prim__float.constructor_2
+      |            prim__float.new
+      |            ^.v.mod
+      |              right.v
+      |
+      |    seq > @
+      |      this
+      |
+      |  [this] > constructor_1
+      |    seq > @
+      |      super.constructor_1
+      |        this
+      |
+      |  [this target] > constructor_2
+      |    seq > @
+      |      super.constructor_2
+      |        this
+      |        target
+      |
+      |  [this another_num] > constructor_3
+      |    seq > @
+      |      super.constructor_3
+      |        this
+      |        another_num
+      |""".stripMargin,
+    """
+      |# inc_pre, dec_pre, inc_post, dec_post, add, sub, mul, div are not precise operators
+      |+package stdlib.primitives
+      |+alias stdlib.primitives.prim__num
+      |
+      |[] > prim__int
+      |  prim__num > super
+      |  super > @
+      |  2147483647 > max_int
+      |  -2147483648 > min_int
+      |
+      |  [] > new
+      |    [] > this
+      |      memory > v
+      |      prim__num.new > super
+      |      super > @
+      |      "prim__int" > prim_name
+      |
+      |      [] > inc_pre
+      |        seq > @
+      |          ^.v.write
+      |            ^.v.add
+      |              1
+      |          prim__int.constructor_3
+      |            prim__int.new
+      |            ^
+      |
+      |      [] > dec_pre
+      |        seq > @
+      |          ^.v.write
+      |            ^.v.sub
+      |              1
+      |          prim__int.constructor_3
+      |            prim__int.new
+      |            ^
+      |
+      |      [] > inc_post
+      |        prim__int.constructor_1 > old
+      |          prim__int.new
+      |        seq > @
+      |          old.v.write
+      |            ^.v
+      |          ^.v.write
+      |            ^.v.add
+      |              1
+      |          old
+      |
+      |      [] > dec_post
+      |        prim__int.constructor_1 > old
+      |          prim__int.new
+      |        seq > @
+      |          old.v.write
+      |            ^.v
+      |          ^.v.write
+      |            ^.v.sub
+      |              1
+      |          old
+      |
+      |      [right] > write
+      |        seq > @
+      |          ^.v.write
+      |            right.v
+      |          prim__int.constructor_3
+      |            prim__int.new
+      |            ^
+      |
+      |      [right] > add
+      |        seq > @
+      |          prim__int.constructor_2
+      |            prim__int.new
+      |            ^.v.add
+      |              right.v
+      |
+      |      [right] > sub
+      |        seq > @
+      |          prim__int.constructor_2
+      |            prim__int.new
+      |            ^.v.sub
+      |              right.v
+      |
+      |      [right] > mul
+      |        seq > @
+      |          prim__int.constructor_2
+      |            prim__int.new
+      |            ^.v.mul
+      |              right.v
+      |
+      |      [right] > div
+      |        seq > @
+      |          prim__int.constructor_2
+      |            prim__int.new
+      |            ^.v.div
+      |              right.v
+      |
+      |      [right] > mod
+      |        seq > @
+      |          prim__int.constructor_2
+      |            prim__int.new
+      |            ^.v.mod
+      |              right.v
+      |
+      |    seq > @
+      |      this
+      |
+      |  [right] > from
+      |    seq > @
+      |      prim__int.constructor_2
+      |        prim__int.new
+      |        mod.
+      |          right.integer_part
+      |            right
+      |          max_int
+      |
+      |  [this] > constructor_1
+      |    seq > @
+      |      super.constructor_1
+      |        this
+      |
+      |  [this target] > constructor_2
+      |    seq > @
+      |      super.constructor_2
+      |        this
+      |        target
+      |
+      |  [this another_num] > constructor_3
+      |    seq > @
+      |      super.constructor_3
+      |        this
+      |        another_num
+      |""".stripMargin,
+    """
+      |+package stdlib.primitives
+      |+alias stdlib.primitives.prim__boolean
+      |
+      |[] > prim__num
+      |  [] > new
+      |    []> this
+      |      memory > v
+      |      "prim__num" > prim_name
+      |      "prim" > @
+      |
+      |      [] > as-string
+      |        seq > @
+      |          ^.v.as-string
+      |
+      |      [this] > integer_part
+      |        seq > @
+      |          if.
+      |            not.
+      |              this.prim_name.eq "prim__boolean"
+      |            if.
+      |              and.
+      |                not.
+      |                  this.prim_name.eq "prim__float"
+      |                not.
+      |                  this.prim_name.eq "prim__double"
+      |              this.v
+      |              this.v.as-int
+      |            if.
+      |              this.v
+      |              1
+      |              0
+      |
+      |      [this] > float_part
+      |        seq > @
+      |          if.
+      |            not.
+      |              this.prim_name.eq "prim__boolean"
+      |            if.
+      |              and.
+      |                not.
+      |                  this.prim_name.eq "prim__float"
+      |                not.
+      |                  this.prim_name.eq "prim__double"
+      |              this.v.as-float
+      |              this.v
+      |            if.
+      |              this.v
+      |              1.0
+      |              0.0
+      |
+      |      [this value] > init
+      |        seq > @
+      |          this.v.write
+      |            value
+      |
+      |      [right] > eq
+      |        seq > @
+      |          prim__boolean.constructor_2
+      |            prim__boolean.new
+      |            ^.v.eq
+      |              right.v
+      |
+      |      [right] > greater
+      |        seq > @
+      |          prim__boolean.constructor_2
+      |            prim__boolean.new
+      |            ^.v.greater
+      |              right.v
+      |
+      |      [right] > less
+      |        seq > @
+      |          prim__boolean.constructor_2
+      |            prim__boolean.new
+      |            ^.v.less
+      |              right.v
+      |
+      |      [right] > geq
+      |        seq > @
+      |          prim__boolean.constructor_2
+      |            prim__boolean.new
+      |            ^.v.geq
+      |              right.v
+      |
+      |      [right] > leq
+      |        seq > @
+      |          prim__boolean.constructor_2
+      |            prim__boolean.new
+      |            ^.v.leq
+      |              right.v
+      |
+      |      [right] > neq
+      |        seq > @
+      |          prim__boolean.constructor_2
+      |            prim__boolean.new
+      |            ^.v.neq
+      |              right.v
+      |
+      |    seq > @
+      |      this
+      |
+      |  [this] > constructor_1
+      |    seq > @
+      |      this
+      |
+      |  [this target] > constructor_2
+      |    seq > @
+      |      this.init
+      |        this
+      |        target
+      |      this
+      |
+      |  [this another_num] > constructor_3
+      |    seq > @
+      |      this.init
+      |        this
+      |        another_num.v
+      |      this
+      |""".stripMargin,
+    """
+      |# inc_pre, dec_pre, inc_post, dec_post, add, sub, mul, div are not precise operators
+      |+package stdlib.primitives
+      |+alias stdlib.primitives.prim__num
+      |
+      |[] > prim__short
+      |  prim__num > super
+      |  super > @
+      |
+      |  [] > new
+      |    [] > this
+      |      memory > v
+      |      prim__num.new > super
+      |      super > @
+      |      "prim__short" > prim_name
+      |
+      |      [] > inc_pre
+      |        seq > @
+      |          ^.v.write
+      |            ^.v.add
+      |              1
+      |          prim__short.constructor_3
+      |            prim__short.new
+      |            ^
+      |
+      |      [] > dec_pre
+      |        seq > @
+      |          ^.v.write
+      |            ^.v.sub
+      |              1
+      |          prim__short.constructor_3
+      |            prim__short.new
+      |            ^
+      |
+      |      [] > inc_post
+      |        prim__short.constructor_1 > old
+      |          prim__short.new
+      |        seq > @
+      |          old.v.write
+      |            ^.v
+      |          ^.v.write
+      |            ^.v.add
+      |              1
+      |          old
+      |
+      |      [] > dec_post
+      |        prim__short.constructor_1 > old
+      |          prim__short.new
+      |        seq > @
+      |          old.v.write
+      |            ^.v
+      |          ^.v.write
+      |            ^.v.sub
+      |              1
+      |          old
+      |
+      |      [right] > write
+      |        seq > @
+      |          ^.v.write
+      |            right.v
+      |          prim__short.constructor_3
+      |            prim__short.new
+      |            ^
+      |
+      |      [right] > add
+      |        seq > @
+      |          prim__short.constructor_2
+      |            prim__short.new
+      |            ^.v.add
+      |              right.v
+      |
+      |      [right] > sub
+      |        seq > @
+      |          prim__short.constructor_2
+      |            prim__short.new
+      |            ^.v.sub
+      |              right.v
+      |
+      |      [right] > mul
+      |        seq > @
+      |          prim__short.constructor_2
+      |            prim__short.new
+      |            ^.v.mul
+      |              right.v
+      |
+      |      [right] > div
+      |        seq > @
+      |          prim__short.constructor_2
+      |            prim__short.new
+      |            ^.v.div
+      |              right.v
+      |
+      |      [right] > mod
+      |        seq > @
+      |          prim__short.constructor_2
+      |            prim__short.new
+      |            ^.v.mod
+      |              right.v
+      |
+      |    seq > @
+      |      this
+      |
+      |  [this] > constructor_1
+      |    seq > @
+      |      super.constructor_1
+      |        this
+      |
+      |  [this target] > constructor_2
+      |    seq > @
+      |      super.constructor_2
+      |        this
+      |        target
+      |
+      |  [this another_num] > constructor_3
+      |    seq > @
+      |      super.constructor_3
+      |        this
+      |        another_num
+      |""".stripMargin,
+    """
+      |# inc_pre, dec_pre, inc_post, dec_post, add, sub, mul, div are not precise operators
+      |+package stdlib.primitives
+      |+alias stdlib.primitives.prim__num
+      |
+      |[] > prim__long
+      |  prim__num > super
+      |  super > @
+      |
+      |  [] > new
+      |    [] > this
+      |      memory > v
+      |      prim__num.new > super
+      |      super > @
+      |      "prim__long" > prim_name
+      |
+      |      [] > inc_pre
+      |        seq > @
+      |          ^.v.write
+      |            ^.v.add
+      |              1
+      |          prim__long.constructor_3
+      |            prim__long.new
+      |            ^
+      |
+      |      [] > dec_pre
+      |        seq > @
+      |          ^.v.write
+      |            ^.v.sub
+      |              1
+      |          prim__long.constructor_3
+      |            prim__long.new
+      |            ^
+      |
+      |      [] > inc_post
+      |        prim__long.constructor_1 > old
+      |          prim__long.new
+      |        seq > @
+      |          old.v.write
+      |            ^.v
+      |          ^.v.write
+      |            ^.v.add
+      |              1
+      |          old
+      |
+      |      [] > dec_post
+      |        prim__long.constructor_1 > old
+      |          prim__long.new
+      |        seq > @
+      |          old.v.write
+      |            ^.v
+      |          ^.v.write
+      |            ^.v.sub
+      |              1
+      |          old
+      |
+      |      [right] > write
+      |        seq > @
+      |          ^.v.write
+      |            right.v
+      |          prim__long.constructor_3
+      |            prim__long.new
+      |            ^
+      |
+      |      [right] > add
+      |        seq > @
+      |          prim__long.constructor_2
+      |            prim__long.new
+      |            ^.v.add
+      |              right.v
+      |
+      |      [right] > sub
+      |        seq > @
+      |          prim__long.constructor_2
+      |            prim__long.new
+      |            ^.v.sub
+      |              right.v
+      |
+      |      [right] > mul
+      |        seq > @
+      |          prim__long.constructor_2
+      |            prim__long.new
+      |            ^.v.mul
+      |              right.v
+      |
+      |      [right] > div
+      |        seq > @
+      |          prim__long.constructor_2
+      |            prim__long.new
+      |            ^.v.div
+      |              right.v
+      |
+      |      [right] > mod
+      |        seq > @
+      |          prim__long.constructor_2
+      |            prim__long.new
+      |            ^.v.mod
+      |              right.v
+      |
+      |    seq > @
+      |      this
+      |
+      |  [this] > constructor_1
+      |    seq > @
+      |      super.constructor_1
+      |        this
+      |
+      |  [this target] > constructor_2
+      |    seq > @
+      |      super.constructor_2
+      |        this
+      |        target
+      |
+      |  [this another_num] > constructor_3
+      |    seq > @
+      |      super.constructor_3
+      |        this
+      |        another_num
+      |""".stripMargin,
+  )
+
+}

--- a/analysis/src/main/scala/org/polystat/odin/analysis/utils/logicalextraction/ExtractLogic.scala
+++ b/analysis/src/main/scala/org/polystat/odin/analysis/utils/logicalextraction/ExtractLogic.scala
@@ -332,7 +332,8 @@ object ExtractLogic {
                       And(arg.properties, arg.value)
                     )
                   )
-                case _ => Left(
+                case _ =>
+                  Left(
                     Nel.one(
                       s"Unsupported ${infoArgs.length}-ary primitive $name"
                     )
@@ -416,6 +417,15 @@ object ExtractLogic {
                           And(Not(infoSrc.value), ifFalse.properties)
                         )
                       )
+                    )
+                  )
+                case ("mod", infoArg :: Nil) =>
+                  Right(
+                    LogicInfo(
+                      List.empty,
+                      List.empty,
+                      Mod(infoSrc.value, infoArg.value),
+                      And(infoSrc.properties, infoArg.properties)
                     )
                   )
                 case _ =>

--- a/analysis/src/main/scala/org/polystat/odin/analysis/utils/logicalextraction/SMTUtils.scala
+++ b/analysis/src/main/scala/org/polystat/odin/analysis/utils/logicalextraction/SMTUtils.scala
@@ -86,12 +86,18 @@ object SMTUtils {
       case _ => IntSort()
     }
 
+    val value = info.value match {
+      case QualifiedIdentifier(SimpleIdentifier(SSymbol("no-value")), _) =>
+        SNumeral(8008)
+      case other => other
+    }
+
     val valueDef =
       FunDef(
         SMTUtils.mkValueFunSSymbol(name.name.name, List(tag)),
         info.forall,
         valueSort,
-        info.value
+        value
       )
     val propertiesDef =
       FunDef(

--- a/analysis/src/test/resources/mutualrec/with_recursion/j2eo.eo
+++ b/analysis/src/test/resources/mutualrec/with_recursion/j2eo.eo
@@ -3,12 +3,6 @@
 +alias stdlib.lang.class__Object
 +alias stdlib.primitives.prim__int
 
-[] > class__Object
-  [] > new
-    [] > this
-  [this] > constructor
-    this > @
-
 [] > class__MutualRec
   class__Object > super
   super > @

--- a/analysis/src/test/resources/mutualrec/with_recursion/random_j2eo_test.eo
+++ b/analysis/src/test/resources/mutualrec/with_recursion/random_j2eo_test.eo
@@ -4,12 +4,6 @@
 +alias stdlib.primitives.prim__int
 +alias org.eolang.gray.cage
 
-[] > class__Object
-  [] > new
-    [] > this
-  [this] > constructor
-    this > @
-
 [] > class__Base
   class__Object > super
   super > @

--- a/analysis/src/test/scala/org/polystat/odin/analysis/DetectStateAccessTests.scala
+++ b/analysis/src/test/scala/org/polystat/odin/analysis/DetectStateAccessTests.scala
@@ -438,7 +438,148 @@ class DetectStateAccessTests extends AnyWordSpec {
       )
     ),
     TestCase(
-      label = "J2EO example of state access",
+      label = "Access to inner state in a tripple nested object",
+      code = """
+               |[] > nest
+               |  [] > prog
+               |    [] > test
+               |      [] > a
+               |        [] > inner_a
+               |          [] > very_inner_a
+               |            memory > state
+               |      [] > b
+               |        a > @
+               |      [] > c
+               |        b > @
+               |      [] > d
+               |        c > @
+               |        [self x] > n
+               |          self.inner_a.very_inner_a.state.add x > @
+               |""".stripMargin,
+      expected = List(
+        "Method 'n' of object 'nest.prog.test.d' directly accesses state 'inner_a.very_inner_a.state' of base class 'nest.prog.test.a'"
+      )
+    ),
+    TestCase(
+      label = "Access to plain state in a double nested object",
+      code = """
+               |[] > prog
+               |  [] > test
+               |    [] > a
+               |      memory > state
+               |    [] > b
+               |      a > @
+               |    [] > c
+               |      b > @
+               |    [] > d
+               |      c > @
+               |      [self x] > n
+               |        self.state.add x > @
+               |""".stripMargin,
+      expected = List(
+        "Method 'n' of object 'prog.test.d' directly accesses state 'state' of base class 'prog.test.a'"
+      )
+    ),
+    TestCase(
+      label = "J2EO example with custom primitives",
+      code =
+        """
+          |# 2022-05-25T15:02:28.522793500
+          |# j2eo team
+          |+alias stdlib.lang.class__Object
+          |+alias stdlib.lang.class__System
+          |+alias stdlib.primitives.prim__int
+          |+alias stdlib.primitives.prim__float
+          |+alias org.eolang.gray.cage
+          |
+          |[] > class__A
+          |  class__Object > super
+          |  super > @
+          |  [] > new
+          |    [] > this
+          |      class__Object.new > super
+          |      super > @
+          |      "class__A" > className
+          |      [this] > init
+          |        seq > @
+          |          d1987169128
+          |        [] > d1987169128
+          |          this.state.write > @
+          |            i_s1239183618
+          |        [] > i_s1239183618
+          |          l1804379080 > @
+          |        [] > l1804379080
+          |          prim__int.constructor_2 > @
+          |            prim__int.new
+          |            0
+          |      prim__int.constructor_1 > state
+          |        prim__int.new
+          |      prim__float.constructor_1 > state2
+          |        prim__float.new
+          |    seq > @
+          |      this
+          |  # null :: null -> void
+          |  [this] > constructor
+          |    seq > @
+          |      initialization
+          |      s1757880885
+          |      this
+          |    [] > initialization
+          |      this.init > @
+          |        this
+          |    [] > s1757880885
+          |      super.constructor > @
+          |        this.super
+          |
+          |[] > class__B
+          |  class__A > super
+          |  super > @
+          |  [] > new
+          |    [] > this
+          |      class__A.new > super
+          |      super > @
+          |      "class__B" > className
+          |      [this] > init
+          |        seq > @
+          |          TRUE
+          |      # n :: int -> int
+          |      [this x] > n
+          |        seq > @
+          |          s278240974
+          |        [] > s278240974
+          |          b980138431 > @
+          |        [] > b980138431
+          |          s_r888655833.add > @
+          |            s_r1710265848
+          |        [] > s_r888655833
+          |          seq > @
+          |            this.state
+          |            this.state2
+          |        [] > s_r1710265848
+          |          x > @
+          |    seq > @
+          |      this
+          |  # null :: null -> void
+          |  [this] > constructor
+          |    seq > @
+          |      initialization
+          |      s1504642150
+          |      this
+          |    [] > initialization
+          |      this.init > @
+          |        this
+          |    [] > s1504642150
+          |      super.constructor > @
+          |        this.super
+          |
+          |""".stripMargin,
+      expected = List(
+        "Method 'n' of object 'class__B.new.this' directly accesses state 'state' of base class 'class__A.new.this'",
+        "Method 'n' of object 'class__B.new.this' directly accesses state 'state2' of base class 'class__A.new.this'"
+      )
+    ),
+    TestCase(
+      label = "J2EO example of state access (with inlined primitives)",
       code =
         """
           |[] > class__A
@@ -540,6 +681,18 @@ class DetectStateAccessTests extends AnyWordSpec {
                |  memory > local_state
                |  [self] > func
                |    self.local_state.write 10 > @
+               |""".stripMargin,
+      expected = List()
+    ),
+    TestCase(
+      label = "Access to state that is locally redefined",
+      code = """[] > a
+               |  memory > state
+               |[] > b
+               |  a > @
+               |  memory > state
+               |  [self] > func
+               |    self.state.write 10 > @
                |""".stripMargin,
       expected = List()
     )


### PR DESCRIPTION
The following changes are included:
- Added some j2eo code test cases
- Added j2eo primitives to predef
- Made it so that the analyzers considers j2eo predefs as state containers
- Refactoring of the analyzer