### PR TITLE
Support for imports

### DIFF
--- a/analysis/src/main/scala/org/polystat/odin/analysis/EOOdinAnalyzer.scala
+++ b/analysis/src/main/scala/org/polystat/odin/analysis/EOOdinAnalyzer.scala
@@ -1,7 +1,8 @@
 package org.polystat.odin.analysis
 
 import cats._
-import cats.data.{EitherNel, NonEmptyList}
+import cats.data.EitherNel
+import cats.data.NonEmptyList
 import cats.effect.Sync
 import cats.syntax.all._
 import org.polystat.odin.analysis.EOOdinAnalyzer._
@@ -11,7 +12,8 @@ import org.polystat.odin.analysis.stateaccess.DetectStateAccess
 import org.polystat.odin.analysis.utils.ImportProcessing.prependImports
 import org.polystat.odin.analysis.utils.inlining.Inliner
 import org.polystat.odin.analysis.utils.j2eo
-import org.polystat.odin.core.ast.{EOBndExpr, EOProg}
+import org.polystat.odin.core.ast.EOBndExpr
+import org.polystat.odin.core.ast.EOProg
 import org.polystat.odin.core.ast.astparams.EOExprOnly
 import org.polystat.odin.parser.EoParser
 import org.polystat.odin.parser.eo.Parser

--- a/analysis/src/main/scala/org/polystat/odin/analysis/EOOdinAnalyzer.scala
+++ b/analysis/src/main/scala/org/polystat/odin/analysis/EOOdinAnalyzer.scala
@@ -172,10 +172,10 @@ object EOOdinAnalyzer {
   ): F[OdinAnalysisResult] = for {
     programAst <- parser.parse(eoRepr)
     astWithPredef = addPredef(programAst)
-    mutualRecursionErrors <-
+    analysisError <-
       analyzer
         .analyze(astWithPredef)
 //        .handleErrorWith(_ => Stream.empty)
-  } yield mutualRecursionErrors
+  } yield analysisError
 
 }

--- a/analysis/src/main/scala/org/polystat/odin/analysis/utils/ImportProcessing.scala
+++ b/analysis/src/main/scala/org/polystat/odin/analysis/utils/ImportProcessing.scala
@@ -4,27 +4,30 @@ import cats.ApplicativeError
 import cats.data.NonEmptyList
 import cats.syntax.all._
 import higherkindness.droste.data.Fix
-import org.polystat.odin.core.ast.astparams.EOExprOnly
 import org.polystat.odin.core.ast._
+import org.polystat.odin.core.ast.astparams.EOExprOnly
 
 object ImportProcessing {
 
   case class Importable(
     src: NonEmptyList[String],
-    content: EOObj[EOExprOnly]
+    content: EOExprOnly
   )
 
   def fetchAvailableImportables(src: List[String])(
     bnd: EOBndExpr[EOExprOnly]
-  )(implicit pkg: Option[String]): List[Importable] = Fix.un(bnd.expr) match {
-    case obj @ EOObj(_, _, bndAttrs) =>
-      val currentName = bnd.bndName.name.name
-      val newPath = pkg.toList ++ src.appended(currentName)
+  )(implicit pkg: Option[String]): List[Importable] = {
+    val newPath =
+      NonEmptyList.ofInitLast(src, bnd.bndName.name.name)
+    val fullPath = pkg.map(newPath.prepend).getOrElse(newPath)
 
-      List(
-        Importable(NonEmptyList.fromListUnsafe(newPath), obj)
-      ) ++ bndAttrs.flatMap(fetchAvailableImportables(newPath))
-    case _ => List()
+    bnd.expr match {
+      case obj @ Fix(EOObj(_, _, bndAttrs)) =>
+        List(
+          Importable(fullPath, obj)
+        ) ++ bndAttrs.flatMap(fetchAvailableImportables(newPath.toList))
+      case other => List(Importable(fullPath, other))
+    }
   }
 
   def prependImports[F[_]](
@@ -32,9 +35,6 @@ object ImportProcessing {
   )(implicit
     ae: ApplicativeError[F, Throwable]
   ): F[Map[String, EOProg[EOExprOnly]]] = {
-    val usedImports = fileToAst
-      .toList
-      .toMap
     val availableImports = for {
       prog <- fileToAst.values
       pkg = prog.metas.pack
@@ -45,24 +45,24 @@ object ImportProcessing {
       )
     } yield importable
 
+    def attemptFetchImport: EOMeta => Option[EOBndExpr[EOExprOnly]] = {
+      case EOAliasMeta(alias, src) =>
+        for {
+          imp <-
+            availableImports
+              .find(imp => imp.src == src)
+          boundObj = imp.content
+          name = alias.getOrElse(src.last)
+        } yield EOBndExpr(EOAnyNameBnd(LazyName(name)), boundObj)
+      case _ => None
+    }
+
     ae.fromOption(
-      usedImports
+      fileToAst
         .toList
-        .traverse { case (fileName, prog @ EOProg(_, _)) =>
-          prog
-            .metas
-            .metas
-            .traverse {
-              case EOAliasMeta(alias, src) =>
-                for {
-                  imp <-
-                    availableImports
-                      .find(imp => imp.src == src)
-                  boundObj = imp.content
-                  name = alias.getOrElse(src.last)
-                } yield EOBndExpr(EOAnyNameBnd(LazyName(name)), Fix(boundObj))
-              case _ => None
-            }
+        .traverse { case (fileName, prog @ EOProg(EOMetas(_, metas), _)) =>
+          metas
+            .traverse(attemptFetchImport)
             .map(importBnds =>
               (fileName, prog.copy(bnds = prog.bnds.prependedAll(importBnds)))
             )

--- a/analysis/src/main/scala/org/polystat/odin/analysis/utils/ImportProcessing.scala
+++ b/analysis/src/main/scala/org/polystat/odin/analysis/utils/ImportProcessing.scala
@@ -1,0 +1,75 @@
+package org.polystat.odin.analysis.utils
+
+import cats.ApplicativeError
+import cats.data.NonEmptyList
+import cats.syntax.all._
+import higherkindness.droste.data.Fix
+import org.polystat.odin.core.ast.astparams.EOExprOnly
+import org.polystat.odin.core.ast._
+
+object ImportProcessing {
+
+  case class Importable(
+    src: NonEmptyList[String],
+    content: EOObj[EOExprOnly]
+  )
+
+  def fetchAvailableImportables(src: List[String])(
+    bnd: EOBndExpr[EOExprOnly]
+  )(implicit pkg: Option[String]): List[Importable] = Fix.un(bnd.expr) match {
+    case obj @ EOObj(_, _, bndAttrs) =>
+      val currentName = bnd.bndName.name.name
+      val newPath = pkg.toList ++ src.appended(currentName)
+
+      List(
+        Importable(NonEmptyList.fromListUnsafe(newPath), obj)
+      ) ++ bndAttrs.flatMap(fetchAvailableImportables(newPath))
+    case _ => List()
+  }
+
+  def prependImports[F[_]](
+    fileToAst: Map[String, EOProg[EOExprOnly]]
+  )(implicit
+    ae: ApplicativeError[F, Throwable]
+  ): F[Map[String, EOProg[EOExprOnly]]] = {
+    val usedImports = fileToAst
+      .toList
+      .toMap
+    val availableImports = for {
+      prog <- fileToAst.values
+      pkg = prog.metas.pack
+      importable <- prog
+        .bnds
+        .collect { case bnd @ EOBndExpr(_, _) => bnd } flatMap (bnd =>
+        fetchAvailableImportables(List())(bnd)(pkg)
+      )
+    } yield importable
+
+    ae.fromOption(
+      usedImports
+        .toList
+        .traverse { case (fileName, prog @ EOProg(_, _)) =>
+          prog
+            .metas
+            .metas
+            .traverse {
+              case EOAliasMeta(alias, src) =>
+                for {
+                  imp <-
+                    availableImports
+                      .find(imp => imp.src == src)
+                  boundObj = imp.content
+                  name = alias.getOrElse(src.last)
+                } yield EOBndExpr(EOAnyNameBnd(LazyName(name)), Fix(boundObj))
+              case _ => None
+            }
+            .map(importBnds =>
+              (fileName, prog.copy(bnds = prog.bnds.prependedAll(importBnds)))
+            )
+        }
+        .map(_.toMap),
+      new Exception("Could not find necessary imports after parsing")
+    )
+  }
+
+}

--- a/analysis/src/main/scala/org/polystat/odin/analysis/utils/ImportProcessing.scala
+++ b/analysis/src/main/scala/org/polystat/odin/analysis/utils/ImportProcessing.scala
@@ -10,24 +10,65 @@ import org.polystat.odin.core.ast.astparams.EOExprOnly
 object ImportProcessing {
 
   case class Importable(
-    src: NonEmptyList[String],
-    content: EOExprOnly
-  )
+    pkg: Option[String],
+    path: NonEmptyList[String],
+    content: EOExprOnly,
+    srcFile: String
+  ) {
+    val fullSrc: NonEmptyList[String] = pkg.map(path.prepend).getOrElse(path)
+    val isTopLvl: Boolean = path.length == 1
+
+    def toBndExpr(alias: Option[String] = None): EOBndExpr[EOExprOnly] = {
+      val name = alias.getOrElse(path.last)
+      EOBndExpr(EOAnyNameBnd(LazyName(name)), content)
+    }
+
+  }
 
   def fetchAvailableImportables(src: List[String])(
     bnd: EOBndExpr[EOExprOnly]
-  )(implicit pkg: Option[String]): List[Importable] = {
+  )(implicit pkg: Option[String], sourceFile: String): List[Importable] = {
     val newPath =
       NonEmptyList.ofInitLast(src, bnd.bndName.name.name)
-    val fullPath = pkg.map(newPath.prepend).getOrElse(newPath)
 
     bnd.expr match {
       case obj @ Fix(EOObj(_, _, bndAttrs)) =>
         List(
-          Importable(fullPath, obj)
+          Importable(pkg, newPath, obj, sourceFile)
         ) ++ bndAttrs.flatMap(fetchAvailableImportables(newPath.toList))
-      case other => List(Importable(fullPath, other))
+      case other => List(Importable(pkg, newPath, other, sourceFile))
     }
+  }
+
+  def fetchImports(
+    availableImports: List[Importable]
+  )(meta: EOMetas): Option[Vector[EOBndExpr[EOExprOnly]]] = {
+    val currentPkg = meta.pack
+
+    val pkgImports = availableImports.collect {
+      case imp @ Importable(pkg, _, _, _)
+           if pkg == currentPkg && imp.isTopLvl => imp.toBndExpr()
+    }
+
+    val nonPkgImports =
+      meta
+        .metas
+        .filter {
+          // Todo: check a special case where the pkg name eq the import name
+          case EOAliasMeta(_, src) if !currentPkg.contains(src.head) => true
+          case _ => false
+        }
+        .traverse {
+          case EOAliasMeta(alias, src) =>
+            for {
+              imp <-
+                availableImports
+                  .find(imp => imp.fullSrc == src)
+            } yield imp.toBndExpr(alias)
+          case _ => None
+        }
+
+    nonPkgImports.map(_ ++ pkgImports)
   }
 
   def prependImports[F[_]](
@@ -36,33 +77,19 @@ object ImportProcessing {
     ae: ApplicativeError[F, Throwable]
   ): F[Map[String, EOProg[EOExprOnly]]] = {
     val availableImports = for {
-      prog <- fileToAst.values
+      (file, prog) <- fileToAst.toList
       pkg = prog.metas.pack
       importable <- prog
         .bnds
-        .collect { case bnd @ EOBndExpr(_, _) => bnd } flatMap (bnd =>
-        fetchAvailableImportables(List())(bnd)(pkg)
-      )
+        .collect { case bnd @ EOBndExpr(_, _) => bnd }
+        .flatMap(bnd => fetchAvailableImportables(List())(bnd)(pkg, file))
     } yield importable
-
-    def attemptFetchImport: EOMeta => Option[EOBndExpr[EOExprOnly]] = {
-      case EOAliasMeta(alias, src) =>
-        for {
-          imp <-
-            availableImports
-              .find(imp => imp.src == src)
-          boundObj = imp.content
-          name = alias.getOrElse(src.last)
-        } yield EOBndExpr(EOAnyNameBnd(LazyName(name)), boundObj)
-      case _ => None
-    }
 
     ae.fromOption(
       fileToAst
         .toList
-        .traverse { case (fileName, prog @ EOProg(EOMetas(_, metas), _)) =>
-          metas
-            .traverse(attemptFetchImport)
+        .traverse { case (fileName, prog @ EOProg(meta, _)) =>
+          fetchImports(availableImports)(meta)
             .map(importBnds =>
               (fileName, prog.copy(bnds = prog.bnds.prependedAll(importBnds)))
             )


### PR DESCRIPTION
This PR introduces a new interface with support for imports (`analyzeSourceCodeDir`) for analyzing multiple files.

## Import Definition
In EO, imports refer to the following constructs at the top of the file:
```+alias bndAlias pkgName.bndSrc```
Each import consists of three parts:
1. Optional alias - `bndAlias` (binding name can be changed when its imported);
2. Optional package name - `pkgName` (packageless objects are stored are a part of the global package with no name);
3. Path to the imported binding -`bndSrc` (can be either a top-level object or a path to some nested binding).

## Supported Functionality
The following import functionality is currently supported:
- Importing of packageless bindings
`+alias objName`
`+alias objName.pathToNestedBnd`

- Importing of bindings with package
`+alias pkgName.srcPath`

- Aliasing in Imports
`+alias name pkgName.srcPath`

- Sharing of top-level objects within the same package
  **File1:**
  ```
  +package pkg
  [] > a
  ```
  **File2:**
  ```
  +package pkg
  [] > b
    a > @
  ```


  
## Unsupported Features
The following features NOT supported:
- Package imports
  **File1:**
  ```
  +package pkg
  [] > a
  ```
  **File2:**
  ```
  +package pkg
  [] > b
    a > @
  ```
  **File3:**
  ```
  +alias pkg
  [] > b
    a > @
  ```

- Recursive import fetching (imports of imports)
  Notice how object `a` is also added to **File3**
  **File1:**
  ```
  +package pkg1
  [] > a
  ```
  **File2:**
  ```
  +package pkg2
  +alias pkg1.a 
  [] > b
    a > @
  ```
  **File3:**
  ```
  +alias pkg2.b
  [] > c
    a > @
  [] >d
    b > @
  ```
  